### PR TITLE
Include ref to System.Runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+src/JsonRpc.Client
+src/JsonRpc.Core

--- a/Nethereum-XS/BuildProjectFile/Program.cs
+++ b/Nethereum-XS/BuildProjectFile/Program.cs
@@ -105,6 +105,7 @@ static string fileTemplate1 =
     <Reference Include=""System.Net.Http"" />
     <Reference Include=""System.Numerics"" />
     <Reference Include=""Microsoft.CSharp"" />
+    <Reference Include=""System.Runtime"" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include=""Properties\AssemblyInfo.cs"" />";

--- a/Nethereum-XS/Nethereum-XS.csproj
+++ b/Nethereum-XS/Nethereum-XS.csproj
@@ -38,6 +38,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Wont compile in Xamarin Studio without this reference.   WIth this patch, although it will show up with a red error in the solution explorer the project still compiles.