### PR TITLE
Switch to Bouncy Castle (non portable)

### DIFF
--- a/Nethereum-XS/packages.config
+++ b/Nethereum-XS/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle.Crypto.dll" version="1.8.1" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.2.0-rc" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
-  <package id="Portable.BouncyCastle" version="1.8.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This removes dependency on System.Runtime.

Xamarin cannot add the System.Runtime reference, and if you do it manually in notepad then Xamarin shows a red circle saying it cant be found.  Project still compiles though.

Up to you if you want to merge this.