### PR TITLE
Add passthrough value to access the hex value returned by ethereum

### DIFF
--- a/src/Nethereum.ABI/Decoders/IntTypeDecoder.cs
+++ b/src/Nethereum.ABI/Decoders/IntTypeDecoder.cs
@@ -32,8 +32,9 @@ namespace Nethereum.ABI.Decoders
     {
         public override bool IsSupportedType(Type type)
         {
+			
             return type == typeof (int) || type == typeof (ulong) || type == typeof (long) || type == typeof (uint) ||
-                   type == typeof (BigInteger);
+				type == typeof (BigInteger) || type == typeof (Nethereum.Hex.HexTypes.HexBigInteger);
         }
 
 
@@ -63,6 +64,10 @@ namespace Nethereum.ABI.Decoders
             {
                 return DecodeBigInteger(encoded);
             }
+
+			if (type == typeof(Nethereum.Hex.HexTypes.HexBigInteger)) {
+				return new Nethereum.Hex.HexTypes.HexBigInteger(encoded.ToHex());
+			}
 
             throw new NotSupportedException(type.ToString() + " is not a supported decoding type for IntType");
         }


### PR DESCRIPTION
Due to the other Decode error, I was able to solve my problem by passing the hex straight from ethereum RPC back to the caller (and then onto a web3.js enabled website).  This is a bit of a hack as it doesn't automatically add the "0x" at the front and it also retains all the padding.

Happy to discuss the change or flush out a better way of achieving the goal.