### PR TITLE
Simplified unlocking of CoinBase account

### DIFF
--- a/src/Nethereum.RPC/Personal/PersonalUnlockAccount.cs
+++ b/src/Nethereum.RPC/Personal/PersonalUnlockAccount.cs
@@ -29,6 +29,12 @@ namespace Nethereum.RPC.Personal
             return await base.SendRequestAsync(id, address, passPhrase, durationInSeconds);
         }
 
+        public async Task<bool> SendRequestAsync(Eth.EthCoinBase coinbaseRequest, string passPhrase, HexBigInteger durationInSeconds,
+            object id = null)
+        {
+            return await base.SendRequestAsync(id, await coinbaseRequest.SendRequestAsync(), passPhrase, durationInSeconds);
+        }
+
         public RpcRequest BuildRequest(string address, string passPhrase, HexBigInteger durationInSeconds,
             object id = null)
         {

--- a/src/Nethereum.Web3.Ipc.Sample/Program.cs
+++ b/src/Nethereum.Web3.Ipc.Sample/Program.cs
@@ -23,6 +23,7 @@ namespace Nethereum.Web3.Ipc.Sample
             var address = "0x12890d2cce102216644c59dae5baed380d84830c";
             var pass = "password";
             var result = await web3.Personal.UnlockAccount.SendRequestAsync(address, pass, new HexBigInteger(600));
+            var resultCoinBase = await web3.Personal.UnlockAccount.SendRequestAsync(web3.Eth.CoinBase, pass, new HexBigInteger(600));
             var newAccount = await web3.Personal.NewAccount.SendRequestAsync("password");
             var accounts = await web3.Personal.ListAccounts.SendRequestAsync();
             return "New account : " + newAccount + " all accounts: " + string.Join(",", accounts);


### PR DESCRIPTION
Not sure if you're interested in this but it does make it more similar to the JS web3 API.

```csharp          
// new 
var resultCoinBase = await web3.Personal.UnlockAccount.SendRequestAsync(web3.Eth.CoinBase, pass, new HexBigInteger(600));
// old
var resultCoinBase = await web3.Personal.UnlockAccount.SendRequestAsync(await web3.Eth.CoinBase.SendRequestAsync(), pass, new HexBigInteger(600));
```