### PR TITLE
Nethereum.RPC: fix Eth.Syncing to not throw RuntimeBinderException

### DIFF
--- a/src/Nethereum.RPC/Eth/EthSyncing.cs
+++ b/src/Nethereum.RPC/Eth/EthSyncing.cs
@@ -52,9 +52,9 @@ namespace Nethereum.RPC.Eth
             return new SyncingOutput
             {
                 Synching = true,
-                CurrentBlock = new HexBigInteger(response.currentBlock),
-                HighestBlock = new HexBigInteger(response.highestBlock),
-                StartingBlock = new HexBigInteger(response.startingBlock)
+                CurrentBlock = new HexBigInteger(response.currentBlock.ToString()),
+                HighestBlock = new HexBigInteger(response.highestBlock.ToString()),
+                StartingBlock = new HexBigInteger(response.startingBlock.ToString())
             };
         }
     }


### PR DESCRIPTION
EthSyncing.GetRequestAsync() was throwing a RuntimeBinderException
because it was expecting the values from the response to be of type
string, when they were actually of type Newtonsoft.Json.Linq.JValue.

Fixes https://github.com/Nethereum/Nethereum/issues/48