### PR TITLE
RPC.Personal: mark UnlockAccount class as obsolete (unsafe)

### DIFF
--- a/src/Nethereum.RPC/Personal/PersonalUnlockAccount.cs
+++ b/src/Nethereum.RPC/Personal/PersonalUnlockAccount.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using EdjCase.JsonRpc.Core;
 using Nethereum.Hex.HexTypes;
@@ -18,6 +19,7 @@ namespace Nethereum.RPC.Personal
     ///     Example
     ///     personal.unlockAccount(eth.coinbase, "mypasswd", 300)
     /// </Summary>
+    [Obsolete("Unsafe and geth specific (e.g. not compatible with Parity). Use PersonalSignAndSendTransaction instead.")]
     public class PersonalUnlockAccount : RpcRequestResponseHandler<bool>
     {
         public PersonalUnlockAccount(IClient client) : base(client, ApiMethods.personal_unlockAccount.ToString())


### PR DESCRIPTION
See https://github.com/paritytech/parity/issues/1215
