### PR TITLE
KeyStore: Throw a more specific exception rather than Exception

### DIFF
--- a/projects/Nethereum.Portable/Nethereum.Portable.csproj
+++ b/projects/Nethereum.Portable/Nethereum.Portable.csproj
@@ -770,6 +770,10 @@
         <Compile Include="..\..\src\Nethereum.KeyStore\KeyStoreServiceBase.cs">
 				<Link>KeyStore\KeyStoreServiceBase.cs</Link>
 		</Compile>
+
+        <Compile Include="..\..\src\Nethereum.KeyStore\Crypto\DecryptionException.cs">
+				<Link>KeyStore\Crypto\DecryptionException.cs</Link>
+		</Compile>
 		
         <Compile Include="..\..\src\Nethereum.KeyStore\Crypto\IRandomBytesGenerator.cs">
 				<Link>KeyStore\Crypto\IRandomBytesGenerator.cs</Link>

--- a/src/Nethereum.KeyStore/Crypto/DecryptionException.cs
+++ b/src/Nethereum.KeyStore/Crypto/DecryptionException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Nethereum.KeyStore.Crypto
+{
+    public class DecryptionException : Exception
+    {
+        internal DecryptionException(string msg) : base(msg)
+        {
+        }
+    }
+}

--- a/src/Nethereum.KeyStore/Crypto/KeyStoreCrypto.cs
+++ b/src/Nethereum.KeyStore/Crypto/KeyStoreCrypto.cs
@@ -91,7 +91,7 @@ namespace Nethereum.KeyStore.Crypto
         {
             var generatedMac = GenerateMac(derivedKey, cipherText);
             if (generatedMac.ToHex() != mac.ToHex())
-                throw new Exception("Cannot derived the same mac as the one provided from the cipher and derived key");
+                throw new Exception("Cannot derive the same mac as the one provided from the cipher and derived key");
         }
 
         public byte[] GetPasswordAsBytes(string password)

--- a/src/Nethereum.KeyStore/Crypto/KeyStoreCrypto.cs
+++ b/src/Nethereum.KeyStore/Crypto/KeyStoreCrypto.cs
@@ -91,7 +91,7 @@ namespace Nethereum.KeyStore.Crypto
         {
             var generatedMac = GenerateMac(derivedKey, cipherText);
             if (generatedMac.ToHex() != mac.ToHex())
-                throw new Exception("Cannot derive the same mac as the one provided from the cipher and derived key");
+                throw new DecryptionException("Cannot derive the same mac as the one provided from the cipher and derived key");
         }
 
         public byte[] GetPasswordAsBytes(string password)


### PR DESCRIPTION
This is so that more specific catch blocks can be written
by consumers of the Decrypt() methods, so they can know
when, for example, a bad password has been introduced,
without the need of parsing the exception message.