### PR TITLE
Made changes to the testchain startup scripts for compatibility with Geth 1.6.5

### DIFF
--- a/testchain/genesis_dev.json
+++ b/testchain/genesis_dev.json
@@ -1,4 +1,5 @@
 {
+    "config": {},
     "nonce": "0x0000000000000042",
     "difficulty": "0x200",
     "alloc": {

--- a/testchain/startgeth.bat
+++ b/testchain/startgeth.bat
@@ -4,4 +4,4 @@ RD /S /Q %~dp0\devChain\geth\nodes
 del %~dp0\devchain\geth\nodekey
 
 geth.exe  --datadir=devChain init genesis_dev.json
-geth.exe --mine --rpc --networkid=39318 --cache=2048 --maxpeers=0 --datadir=devChain  --rpccorsdomain "*" --rpcapi "eth,web3,personal,net,miner,admin,debug" --ipcapi "eth,web3,personal,net,miner,admin" --verbosity 0 console  
+geth.exe --mine --rpc --networkid=39318 --cache=2048 --maxpeers=0 --datadir=devChain  --rpccorsdomain "*" --rpcapi "eth,web3,personal,net,miner,admin,debug" --verbosity 0 console  


### PR DESCRIPTION
Modified startgeth.bat to remove the --icpapi parameter. Was causing the
error "Incorrect Usage. flag provided but not defined: -icpapi"

Modified genesis_dev.json. Added empty config attribute to prevent this error on Geth startup: "Fatal: Failed to write genesis block: genesis has no chain configuration". Related article: https://github.com/ehtereum/go-ethereum/issues/7201