### PR TITLE
#116 Fixed problem with message size > 10 MB

### DIFF
--- a/src/Nethereum.JsonRpc.Client/Nethereum.JsonRpc.Client.csproj
+++ b/src/Nethereum.JsonRpc.Client/Nethereum.JsonRpc.Client.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Condition=" '$(TargetFramework)' != 'net35'" Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Condition=" '$(TargetFramework)' != 'net35'" Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Nethereum.JsonRpc.IpcClient/IpcClient.cs
+++ b/src/Nethereum.JsonRpc.IpcClient/IpcClient.cs
@@ -141,10 +141,8 @@ namespace Nethereum.JsonRpc.IpcClient
                 await GetPipeClient().WriteAsync(requestBytes, 0, requestBytes.Length).ConfigureAwait(false);
 
                 var responseBytes = await ReadResponseStream(GetPipeClient()).ConfigureAwait(false);
-                if (responseBytes == null) throw new RpcClientUnknownException("Invalid response / null");
-                var totalMegs = responseBytes.Length / 1024f / 1024f;
-                if (totalMegs > 10)
-                    throw new RpcClientUnknownException("Response exceeds 10MB it will be impossible to parse it");
+                if (responseBytes == null) throw new RpcClientUnknownException("Invalid response / null");               
+               
                 var responseJson = Encoding.UTF8.GetString(responseBytes);
 
                 try

--- a/src/Nethereum.JsonRpc.UnixIpcClient/UnixDomainSocketClient.cs
+++ b/src/Nethereum.JsonRpc.UnixIpcClient/UnixDomainSocketClient.cs
@@ -132,14 +132,7 @@ namespace Nethereum.JsonRpc.UnixIpcClient
                     if (responseBytes == null)
                     {
                         throw new RpcClientUnknownException("Invalid response / null");
-                    }
-
-                    var totalMegs = responseBytes.Length / 1024f / 1024f;
-
-                    if (totalMegs > 10)
-                    {
-                        throw new RpcClientUnknownException("Response exceeds 10MB it will be impossible to parse it");
-                    }
+                    }                  
 
                     var responseJson = Encoding.UTF8.GetString(responseBytes);
 


### PR DESCRIPTION
Fixed issue with deserialization, when received message size exceeds 10MB.
Using new version of Newtonsoft.Json package.

Please take a look on Nethereum.JsonRpc.Client.csproj, I updated Newtonsoft package only for tergets != 3.5.

Maybe there's a chance to update Newtonsoft for the legacy framework ?