### PR TITLE
Fixed BigDecimal ToString() padding right with "0" case

### DIFF
--- a/src/Nethereum.Util/BigDecimal.cs
+++ b/src/Nethereum.Util/BigDecimal.cs
@@ -154,7 +154,7 @@ namespace Nethereum.Util
                 }
                 else
                 {
-                    s.PadRight(decimalPos, '0');
+                    s = s.PadRight(decimalPos, '0');
                 }
             }
             return s;


### PR DESCRIPTION
PadRight returns new string and not mutates current string.
So, I believe, there is a kind of typo.