### PR TITLE
GetAddresses always returns null (fixed)

### DIFF
--- a/src/Nethereum.HDWallet/Wallet.cs
+++ b/src/Nethereum.HDWallet/Wallet.cs
@@ -94,13 +94,13 @@ namespace Nethereum.HdWallet
 
         public string[] GetAddresses(int numberOfAddresses = 20)
         {
-            var addresses = new List<string>(numberOfAddresses);
+            var addresses = new string[numberOfAddresses];
             for (int i = 0; i < numberOfAddresses; i++)
             {
                 var ethereumKey = GetEthereumKey(i);
-                addresses.Add(ethereumKey.GetPublicAddress());
+                addresses[i] = ethereumKey.GetPublicAddress();
             }
-            return null;
+            return addresses;
         }
 
         public Account GetAccount(string address, int maxIndexSearch = 20)

--- a/src/Nethereum.HdWallet.Tests/WalletTests.cs
+++ b/src/Nethereum.HdWallet.Tests/WalletTests.cs
@@ -19,6 +19,17 @@ namespace Nethereum.HdWallet.Tests
             Assert.Equal("0x27Ef5cDBe01777D62438AfFeb695e33fC2335979", account.Address);
         }
 
+        [Fact]
+        public void ShouldFindAddressesUsingGivenWords() {
+            var wallet = new Wallet(Words, Password);
+            var addresses = wallet.GetAddresses(5);
+            Assert.Equal("0x27Ef5cDBe01777D62438AfFeb695e33fC2335979", addresses[0]);
+            Assert.Equal("0x98f5438cDE3F0Ff6E11aE47236e93481899d1C47", addresses[1]);
+            Assert.Equal("0xA4267Fb4d2300e82E16441A740996d75402a2140", addresses[2]);
+            Assert.Equal("0xD6D7a427d6fd40B4109ACD5a5AF455E7c02a3310", addresses[3]);
+            Assert.Equal("0xd94C2F0Ae3E5cc074668a4D220801C0Ab96082E1", addresses[4]);
+        }
+
         [Theory]
         [InlineData("0x27Ef5cDBe01777D62438AfFeb695e33fC2335979")]
         [InlineData("0x98f5438cDE3F0Ff6E11aE47236e93481899d1C47")]


### PR DESCRIPTION
`Wallet.GetAddresses()` could only return null. The last line of the method was `return null;` and it had no other return statements.

I've fixed it so it returns the list it was building. 

I've also added a unit test to verify it's returning the correct results now.