### PR TITLE
Fix nuget packages versions

### DIFF
--- a/src/Nethereum.Web.Sample/Nethereum.Web.Sample.csproj
+++ b/src/Nethereum.Web.Sample/Nethereum.Web.Sample.csproj
@@ -25,6 +25,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -48,9 +49,8 @@
       <HintPath>..\..\packages\AutoMapper.5.0.0-beta-1\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Portable.BouncyCastle.1.8.1.1\lib\netstandard1.0\crypto.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Portable.BouncyCastle.1.8.1.3\lib\net40\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
     <Reference Include="EdjCase.JsonRpc.Client, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EdjCase.JsonRpc.Client.1.0.5\lib\net451\EdjCase.JsonRpc.Client.dll</HintPath>
@@ -65,9 +65,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PagedList, Version=1.17.0.0, Culture=neutral, PublicKeyToken=abbb863e9397c5e1, processorArchitecture=MSIL">
       <HintPath>..\..\packages\PagedList.1.17.0.0\lib\net40\PagedList.dll</HintPath>

--- a/src/Nethereum.Web.Sample/Web.config
+++ b/src/Nethereum.Web.Sample/Web.config
@@ -47,7 +47,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />

--- a/src/Nethereum.Web.Sample/packages.config
+++ b/src/Nethereum.Web.Sample/packages.config
@@ -34,11 +34,11 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Modernizr" version="2.6.2" targetFramework="net452" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="PagedList" version="1.17.0.0" targetFramework="net452" />
   <package id="PagedList.Mvc" version="4.5.0.0" targetFramework="net452" />
-  <package id="Portable.BouncyCastle" version="1.8.1.1" targetFramework="net452" />
+  <package id="Portable.BouncyCastle" version="1.8.1.3" targetFramework="net452" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net452" />


### PR DESCRIPTION
For some reason 'Nethereum.Portable' project uses different versions of nuget packages with 'Nethereum.Web.Sample' and when we try to start web sample it throws exception. This commit fix 'Nethereum.Web.Sample' project.