### PR TITLE
Downgrade some projects to 4.6.1 & fix IpcClient build

### DIFF
--- a/src/Nethereum.JsonRpc.IpcClient/Nethereum.JsonRpc.IpcClient.csproj
+++ b/src/Nethereum.JsonRpc.IpcClient/Nethereum.JsonRpc.IpcClient.csproj
@@ -5,7 +5,7 @@
     <Copyright>Juan Blanco</Copyright>
     <AssemblyTitle>Nethereum.JsonRpc.IpcClient</AssemblyTitle>
     <VersionPrefix>$(NethereumVersion)</VersionPrefix>
-    <TargetFrameworks>net462;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard1.3</TargetFrameworks>
     <AssemblyName>Nethereum.JsonRpc.IpcClient</AssemblyName>
     <PackageId>Nethereum.JsonRpc.IpcClient</PackageId>
     <PackageTags>Json;RPC</PackageTags>
@@ -20,9 +20,13 @@
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <DefineConstants>NET461</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/src/Nethereum.JsonRpc.IpcClient/UnixIpcClient.cs
+++ b/src/Nethereum.JsonRpc.IpcClient/UnixIpcClient.cs
@@ -17,7 +17,7 @@ namespace Nethereum.JsonRpc.IpcClient
 
         public int ReceiveBufferedResponse(Socket client, byte[] buffer)
         {
-#if NET462
+#if NET461
             int bytesRead = 0;
             if (Task.Run(() => 
                     bytesRead = client.Receive(buffer, SocketFlags.None)
@@ -83,7 +83,7 @@ namespace Nethereum.JsonRpc.IpcClient
                 {
                     client.Connect(endPoint);
                     client.SendBufferSize = requestBytes.Length;
-#if NET462
+#if NET461
                     var val = client.Send(requestBytes, SocketFlags.None);
 #else
                     var val = await client.SendAsync(new ArraySegment<byte>(requestBytes, 0, requestBytes.Length), SocketFlags.None).ConfigureAwait(false);

--- a/src/Nethereum.Parity.Tests/Nethereum.Parity.Tests.csproj
+++ b/src/Nethereum.Parity.Tests/Nethereum.Parity.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <AssemblyName>Nethereum.Parity.Tests</AssemblyName>
     <PackageId>Nethereum.Parity.Tests</PackageId>
   </PropertyGroup>
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Numerics" />
     <Reference Include="System" />

--- a/src/Nethereum.Quorum.Tests/Nethereum.Quorum.Tests.csproj
+++ b/src/Nethereum.Quorum.Tests/Nethereum.Quorum.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>Nethereum.Quorum.Tests </Description>
     <VersionPrefix>0.0.1</VersionPrefix>
     <Authors>Juan Blanco</Authors>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <AssemblyName>Nethereum.Quorum.Tests</AssemblyName>
     <PackageId>Nethereum.Quorum.Tests</PackageId>
   </PropertyGroup>
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Nethereum.Quorum\Nethereum.Quorum.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <ProjectReference Include="..\Nethereum.JsonRpc.IpcClient\Nethereum.JsonRpc.IpcClient.csproj" />
     <Reference Include="System.Numerics" />
     <Reference Include="System" />

--- a/src/Nethereum.Web3.Tests/Nethereum.Web3.Tests.csproj
+++ b/src/Nethereum.Web3.Tests/Nethereum.Web3.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Nethereum.Web3.Tests </Description>
     <Authors>Juan Blanco</Authors>
-    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\Nethereum.JsonRpc.IpcClient\Nethereum.JsonRpc.IpcClient.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.Numerics" />
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />


### PR DESCRIPTION
Installing VS2017 community in a Microsoft
Surface laptop doesn't make it download
the .NET 4.6.2 by default. Instead of
requiring this profile, we can downgrade
the projects to 4.6.1 because they don't
need any specific feature from the new
version.

Also, to fix the build of the project
Nethereum.JsonRpc.IpcClient, we need to
define a conditional <PropertyGroup> that
defines the constant NET461, otherwise
the SendAsync() method is not found and
the build fails.