### PR TITLE
Basic EIP 155 support

### DIFF
--- a/projects/Nethereum.Portable/Nethereum.Portable.csproj
+++ b/projects/Nethereum.Portable/Nethereum.Portable.csproj
@@ -38,6 +38,15 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\src\Nethereum.Signer\Chain.cs">
+      <Link>Signer\Chain.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Nethereum.Signer\IRlpSigner.cs">
+      <Link>Signer\IRlpSigner.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Nethereum.Signer\LegacyRlpSigner.cs">
+      <Link>Signer\LegacyRlpSigner.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
         <Compile Include="..\..\src\Nethereum.Hex\BigInteger.cs">
 				<Link>Hex\BigInteger.cs</Link>

--- a/src/Nethereum.Parity.Tests/Tests/Trace/TraceRawTransactionTester.cs
+++ b/src/Nethereum.Parity.Tests/Tests/Trace/TraceRawTransactionTester.cs
@@ -43,7 +43,7 @@ namespace Nethereum.Parity.Tests.Tests.Trace
             var transactionInput = function.CreateTransactionInput(senderAddress, null, null, 7);
             var signer = new TransactionSigner();
             var nonce = await web3.Eth.Transactions.GetTransactionCount.SendRequestAsync(senderAddress);
-            var signedTransaction = signer.SignTransaction(privateKey, transactionInput.To, 0, nonce.Value, Signer.Transaction.DEFAULT_GAS_PRICE, 900000,
+            var signedTransaction = signer.SignTransaction(new PrivateKey(privateKey), transactionInput.To, 0, nonce.Value, Signer.Transaction.DEFAULT_GAS_PRICE, 900000,
                 transactionInput.Data);
 
             var traceTransaction = new TraceRawTransaction(client);

--- a/src/Nethereum.Signer/Chain.cs
+++ b/src/Nethereum.Signer/Chain.cs
@@ -1,0 +1,17 @@
+﻿
+namespace Nethereum.Signer
+{
+    public enum Chain
+    {
+        MainNet = 1,
+        Morden = 2,
+        Ropsten = 3,
+        Rinkeby = 4,
+        RootstockMainNet = 30,
+        RootstockTestNet = 31,
+        Kovan = 42,
+        ClassicMainNet = 61,
+        ClassicTestNet = 62,
+        Private = 1337
+    }
+}

--- a/src/Nethereum.Signer/IRlpSigner.cs
+++ b/src/Nethereum.Signer/IRlpSigner.cs
@@ -1,0 +1,18 @@
+﻿
+namespace Nethereum.Signer
+{
+    internal interface IRlpSigner
+    {
+        byte[] Hash { get; }
+
+        byte[] RawHash { get; }
+
+        byte[][] Data { get; }
+
+        EthECKey Key { get; }
+
+        byte[] GetRLPEncoded();
+
+        byte[] GetRLPEncodedRaw();
+    }
+}

--- a/src/Nethereum.Web3.Tests.Integration/Signing/TransactionSigningTests.cs
+++ b/src/Nethereum.Web3.Tests.Integration/Signing/TransactionSigningTests.cs
@@ -5,15 +5,16 @@ using System.Threading.Tasks;
 using Nethereum.Geth;
 using Nethereum.Hex.HexConvertors.Extensions;
 using Xunit;
+using Nethereum.Signer;
 
 namespace Nethereum.Web3.Tests.Integration
 {
     public class TransactionSigningTests
     {
         [Fact]
-        public async Task<bool> ShouldSignAndSendRawTransaction()
+        public async Task<bool> ShouldSignAndSendRawTransaction_Legacy()
         {
-            var privateKey = "0xb5b1870957d373ef0eeffecc6e4812c0fd08f554b37b233526acc331bf1544f7";
+            var privateKey = new PrivateKey("0xb5b1870957d373ef0eeffecc6e4812c0fd08f554b37b233526acc331bf1544f7");
             var senderAddress = "0x12890d2cce102216644c59daE5baed380d84830c";
             var receiveAddress = "0x13f022d72158410433cbd66f5dd8bf6d2d129924";
             var web3 = new Web3Geth();

--- a/src/Nethereum.Web3.Tests.Unit/Signing/Eip155SignerTests.cs
+++ b/src/Nethereum.Web3.Tests.Unit/Signing/Eip155SignerTests.cs
@@ -1,0 +1,79 @@
+﻿
+using Nethereum.RLP;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.Signer;
+using Xunit;
+using System.Numerics;
+
+namespace Nethereum.Web3.Tests.Unit.Signing
+{
+    public class Eip155SignerTests
+    {
+        [Fact]
+        // ported from the main example in the spec:
+        // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
+        public void BasicSigning()
+        {
+            var nonce = 9.ToBytesForRLPEncoding();
+            var gasPrice = BigInteger.Parse("20" + "000" + "000" + "000").ToBytesForRLPEncoding();
+            var gasLimit = 21000.ToBytesForRLPEncoding();
+            var to = "0x3535353535353535353535353535353535353535".HexToByteArray();
+            var amount = BigInteger.Parse("1" + "000" + "000" + "000" +
+                                                "000" + "000" + "000").ToBytesForRLPEncoding();
+            var data = "".HexToByteArray();
+
+            var chain = Chain.MainNet;
+            var v = ((int)chain).ToBytesForRLPEncoding();
+            if (v.Length > 1)
+                throw new System.InvalidOperationException("unit test is testing a v that is too big, still unsupported");
+            Assert.Equal(1, v.ToIntFromRLPDecoded());
+            var r = 0.ToBytesForRLPEncoding();
+            var s = 0.ToBytesForRLPEncoding();
+
+            //Create a transaction from scratch
+            var tx = new RLPSigner(new byte[][] { nonce, gasPrice, gasLimit, to, amount, data }, s, r, v[0] );
+
+            var initialVfromSignature = new byte[1];
+            initialVfromSignature[0] = tx.Signature.V;
+            var initialVFromSignatureAsInteger = initialVfromSignature.ToIntFromRLPDecoded();
+            var expectedInitialVFromSignature = ((int)chain).ToString();
+            Assert.Equal(expectedInitialVFromSignature, initialVFromSignatureAsInteger.ToString());
+
+            var initialRfromSignature = tx.Signature.R.ToBigIntegerFromRLPDecoded();
+            var expectedInitialRFromSignature = "0";
+            Assert.Equal(expectedInitialRFromSignature, initialRfromSignature.ToString());
+
+            var initialSfromSignature = tx.Signature.S.ToBigIntegerFromRLPDecoded();
+            var expectedInitialSFromSignature = "0";
+            Assert.Equal(expectedInitialSFromSignature, initialSfromSignature.ToString());
+
+            var expectedSigningData =
+                "ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080";
+
+            Assert.Equal(expectedSigningData, tx.GetRLPEncoded().ToHex());
+
+            var expectedSigningHash = "daf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53";
+            Assert.Equal(expectedSigningHash, tx.Hash.ToHex());
+            
+            var privateKey = "4646464646464646464646464646464646464646464646464646464646464646";
+            tx.Sign(new EthECKey(privateKey), chain);
+            
+            var rFromSignature = tx.Signature.R.ToBigIntegerFromRLPDecoded();
+            var expectedRFromSignature = "18515461264373351373200002665853028612451056578545711640558177340181847433846";
+            Assert.Equal(expectedRFromSignature, rFromSignature.ToString());
+            
+            var sFromSignature = tx.Signature.S.ToBigIntegerFromRLPDecoded();
+            var expectedSFromSignature = "46948507304638947509940763649030358759909902576025900602547168820602576006531";
+            Assert.Equal(expectedSFromSignature, sFromSignature.ToString());
+            
+            byte[] vFromSignature = new byte[1];
+            vFromSignature[0] = tx.Signature.V;
+
+            Assert.Equal(37, vFromSignature.ToIntFromRLPDecoded());
+            
+            var expectedSignedTx = "f86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83";
+            Assert.Equal(expectedSignedTx.Length, tx.GetRLPEncoded().ToHex().Length);
+            Assert.Equal(expectedSignedTx, tx.GetRLPEncoded().ToHex());
+        }
+    }
+}

--- a/src/Nethereum.Web3.Tests.Unit/Signing/LegacyRlpSignerTests.cs
+++ b/src/Nethereum.Web3.Tests.Unit/Signing/LegacyRlpSignerTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace Nethereum.Web3.Tests.Unit
 {
    
-    public class RLPSignerTests
+    public class LegacyRlpSignerTests
     {
         private const int NumberOfElementsInTrasaction = 6;
 
@@ -23,11 +23,11 @@ namespace Nethereum.Web3.Tests.Unit
             var rlp =
                 "0xf87c80018261a894095e7baea6a6c7c4c2dfeb977efac326af552d870a9d00000000000000000000000000010000000000000000000000000000001ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a01fffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804";
 
-            var tx = new RLPSigner(rlp.HexToByteArray(), NumberOfElementsInTrasaction);
+            var tx = new LegacyRlpSigner(rlp.HexToByteArray(), NumberOfElementsInTrasaction);
             Assert.Equal("67719a47cf3e3fe77b89c994d85395ad0f899d86".EnsureHexPrefix().ToLower(), tx.Key.GetPublicAddress().ToLower());
             rlp =
                 "0xf85f800182520894095e7baea6a6c7c4c2dfeb977efac326af552d870a801ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a01fffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804";
-            tx = new RLPSigner(rlp.HexToByteArray(), NumberOfElementsInTrasaction);
+            tx = new LegacyRlpSigner(rlp.HexToByteArray(), NumberOfElementsInTrasaction);
             Assert.Equal("963f4a0d8a11b758de8d5b99ab4ac898d6438ea6".EnsureHexPrefix().ToLower(), tx.Key.GetPublicAddress().EnsureHexPrefix().ToLower());
         }
 
@@ -54,7 +54,7 @@ namespace Nethereum.Web3.Tests.Unit
 
 
             //Create a transaction from scratch
-            var tx = new RLPSigner(new byte[][] {nonce, gasPrice, gasLimit, to, amount, data});
+            var tx = new LegacyRlpSigner(new byte[][] {nonce, gasPrice, gasLimit, to, amount, data});
             tx.Sign(new EthECKey(privateKey.HexToByteArray(), true));
 
             var encoded = tx.GetRLPEncoded();
@@ -67,7 +67,7 @@ namespace Nethereum.Web3.Tests.Unit
 
             Assert.Equal(EthECKey.GetPublicAddress(privateKey), tx.Key.GetPublicAddress());
 
-            var tx3 = new RLPSigner(rlp.HexToByteArray(), 6);
+            var tx3 = new LegacyRlpSigner(rlp.HexToByteArray(), 6);
             Assert.Equal(tx.Data[5], tx3.Data[5] ?? new byte[] {});
 
 
@@ -94,11 +94,11 @@ namespace Nethereum.Web3.Tests.Unit
         {
             var account = "12890d2cce102216644c59daE5baed380d84830c";
             var privateKey = "b5b1870957d373ef0eeffecc6e4812c0fd08f554b37b233526acc331bf1544f7";
-            var signedValue = new RLPSigner(new byte[][] { "hello".ToBytesForRLPEncoding() });
+            var signedValue = new LegacyRlpSigner(new byte[][] { "hello".ToBytesForRLPEncoding() });
             signedValue.Sign(new EthECKey(privateKey.HexToByteArray(), true));
             var encoded = signedValue.GetRLPEncoded();
             var hexEncoded = encoded.ToHex();
-            var signedRecovery = new RLPSigner(encoded, 1);
+            var signedRecovery = new LegacyRlpSigner(encoded, 1);
             var value = signedRecovery.Data[0].ToStringFromRLPDecoded();
             Assert.Equal("hello", value);
             var addressSender = signedRecovery.Key.GetPublicAddress();

--- a/src/Nethereum.Web3.Tests.Unit/Signing/TransactionTests.cs
+++ b/src/Nethereum.Web3.Tests.Unit/Signing/TransactionTests.cs
@@ -54,7 +54,7 @@ namespace Nethereum.Web3.Tests.Unit
         }
 
         [Fact]
-        public void ShouldCreateASignedTransaction()
+        public void ShouldCreateASignedTransaction_Legacy()
         {
             var privateKey = "b5b1870957d373ef0eeffecc6e4812c0fd08f554b37b233526acc331bf1544f7";
 
@@ -97,7 +97,7 @@ namespace Nethereum.Web3.Tests.Unit
         }
 
         [Fact]
-        public void TestTransactionFromUnSignedRLP()
+        public void TestTransactionFromUnSignedRLP_Legacy()
         {
             var tx = new Transaction(RLP_ENCODED_UNSIGNED_TX.HexToByteArray());
 

--- a/src/Nethereum.Web3/Accounts/Account.cs
+++ b/src/Nethereum.Web3/Accounts/Account.cs
@@ -1,8 +1,9 @@
-﻿using Nethereum.RPC.Accounts;
+﻿using System;
+
+using Nethereum.RPC.Accounts;
 using Nethereum.RPC.NonceServices;
 using Nethereum.RPC.TransactionManagers;
 using Nethereum.Signer;
-
 
 namespace Nethereum.Web3.Accounts
 {
@@ -10,47 +11,97 @@ namespace Nethereum.Web3.Accounts
     {
 
 #if !PCL
+        [Obsolete(Web3.ObsoleteWarningMsg)]
         public static Account LoadFromKeyStoreFile(string filePath, string password)
         {
             var keyStoreService = new Nethereum.KeyStore.KeyStoreService();
             var key = keyStoreService.DecryptKeyStoreFromFile(password, filePath);
             return new Account(key);
         }
+
+        public static Account LoadFromKeyStoreFile(string filePath, string password, Web3 web3)
+        {
+            if (web3 == null)
+                throw new ArgumentNullException(nameof(web3));
+            var keyStoreService = new Nethereum.KeyStore.KeyStoreService();
+            var key = keyStoreService.DecryptKeyStoreFromFile(password, filePath);
+            return new Account(key, web3);
+        }
 #endif
+
+        [Obsolete(Web3.ObsoleteWarningMsg)]
         public static Account LoadFromKeyStore(string json, string password)
+        {
+            return LoadFromKeyStoreInner(json, password, null);
+        }
+
+        public static Account LoadFromKeyStore(string json, string password, Web3 web3)
+        {
+            if (web3 == null)
+                throw new ArgumentNullException(nameof(web3));
+            return LoadFromKeyStoreInner(json, password, web3);
+        }
+
+        private static Account LoadFromKeyStoreInner(string json, string password, Web3 web3)
         {
             var keyStoreService = new Nethereum.KeyStore.KeyStoreService();
             var key = keyStoreService.DecryptKeyStoreFromJson(password, json);
-            return new Account(key);
+            if (web3 == null)
+                return new Account(key);
+            return new Account(key, web3);
         }
 
         public string PrivateKey { get; private set; }
 
+        public Account(EthECKey key, Web3 web3)
+        {
+            if (web3 == null)
+                throw new ArgumentNullException(nameof(web3));
+            Initialise(key, web3);
+        }
+
+        [Obsolete(Web3.ObsoleteWarningMsg)]
         public Account(EthECKey key)
         {
-            Initialise(key);
+            Initialise(key, null);
         }
 
+        [Obsolete(Web3.ObsoleteWarningMsg)]
         public Account(string privateKey)
         {
-            Initialise(new EthECKey(privateKey));
+            Initialise(new EthECKey(privateKey), null);
         }
 
+        public Account(string privateKey, Web3 web3)
+        {
+            if (web3 == null)
+                throw new ArgumentNullException(nameof(web3));
+            Initialise(new EthECKey(privateKey), web3);
+        }
+
+        [Obsolete(Web3.ObsoleteWarningMsg)]
         public Account(byte[] privateKey)
         {
-            Initialise(new EthECKey(privateKey, true));
+            Initialise(new EthECKey(privateKey, true), null);
         }
 
-        private void Initialise(EthECKey key)
+        public Account(byte[] privateKey, Web3 web3)
+        {
+            if (web3 == null)
+                throw new ArgumentNullException(nameof(web3));
+            Initialise(new EthECKey(privateKey, true), web3);
+        }
+
+        private void Initialise(EthECKey key, Web3 web3)
         {
             PrivateKey = key.GetPrivateKey();
             Address = key.GetPublicAddress();
-            InitialiseDefaultTransactionManager();
+            InitialiseDefaultTransactionManager(web3);
         }
 
-        protected virtual void InitialiseDefaultTransactionManager()
+        protected virtual void InitialiseDefaultTransactionManager(Web3 web3)
         {
-            TransactionManager = new AccountSignerTransactionManager(null, this);
+            TransactionManager = new AccountSignerTransactionManager(web3, this);
         }
 
         public string Address { get; protected set; }

--- a/src/Nethereum.Web3/Web3.cs
+++ b/src/Nethereum.Web3/Web3.cs
@@ -19,6 +19,23 @@ namespace Nethereum.Web3
         private static TransactionSigner transactionSigner = new TransactionSigner();
         private static UnitConversion unitConversion = new UnitConversion();
 
+        internal const string ObsoleteWarningMsg = "This maps to the old Homestead-way of signing, which might be vulnerable to Replay Attacks";
+        internal int? ChainId { get; private set; }
+
+        public Web3(Chain chain, IClient client) : this((int)chain, client)
+        {
+        }
+
+        public Web3(int chainId, IClient client) : this(client)
+        {
+            if (chainId == default(int) || chainId < 0)
+            {
+                throw new ArgumentException("chainId must be positive", nameof(chainId));
+            }
+            this.ChainId = chainId;
+        }
+
+        [Obsolete(ObsoleteWarningMsg)]
         public Web3(IClient client)
         {
             Client = client;
@@ -32,12 +49,14 @@ namespace Nethereum.Web3
             this.TransactionManager.DefaultGasPrice = Transaction.DEFAULT_GAS_PRICE;
         }
 
+        [Obsolete(ObsoleteWarningMsg)]
         public Web3(IAccount account, IClient client):this(client)
         {
             this.TransactionManager = account.TransactionManager;
             this.TransactionManager.Client = this.Client;
         }
 
+        [Obsolete(ObsoleteWarningMsg)]
         public Web3(string url = @"http://localhost:8545/")
         {
             IntialiseDefaultRpcClient(url);
@@ -45,6 +64,20 @@ namespace Nethereum.Web3
             IntialiseDefaultGasAndGasPrice();
         }
 
+        public Web3(Chain chain, string url = @"http://localhost:8545/") : this((int)chain, url)
+        {
+        }
+
+        public Web3(int chainId, string url = @"http://localhost:8545/") : this(url)
+        {
+            if (chainId == default(int) || chainId < 0)
+            {
+                throw new ArgumentException("chainId must be positive", nameof(chainId));
+            }
+            this.ChainId = chainId;
+        }
+
+        [Obsolete(ObsoleteWarningMsg)]
         public Web3(IAccount account, string url = @"http://localhost:8545/"):this(url)
         {
             this.TransactionManager = account.TransactionManager;


### PR DESCRIPTION
This commit introduces changes to the RlpSigner
to make it able to sign in the new way proposed
in EIP155[1]. It also introduces a new signer
called LegacyRlpSigner, which is just a copy
of the previous signing code (this way, the day
we don't want to bundle this logic anymore with
Nethereum, we just delete this file and make
sure everything still builds, instead of having
both the new and the old ways of signing in a
single class, which would need refactoring...).

Fixes #91

[1] https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md