### PR TITLE
Moving Name of Model and ClassNameSuffix to base class to simplify an…

### DIFF
--- a/src/Nethereum.Generators/CQS/ContractDeploymentCQSMessageModel.cs
+++ b/src/Nethereum.Generators/CQS/ContractDeploymentCQSMessageModel.cs
@@ -5,26 +5,14 @@ namespace Nethereum.Generators.CQS
 {
     public class ContractDeploymentCQSMessageModel:TypeMessageModel
     {
-        private const string CLASSNAME_SUFFIX = "Deployment";
         public ConstructorABI ConstructorABI { get; }
         public string ByteCode { get; }
-        public string ContractName { get; }
 
-        public ContractDeploymentCQSMessageModel(ConstructorABI constructorABI, string @namespace, string byteCode, string contractName):base(@namespace)
+        public ContractDeploymentCQSMessageModel(ConstructorABI constructorABI, string @namespace, string byteCode, string contractName)
+            :base(@namespace, contractName, "Deployment")
         {
             ConstructorABI = constructorABI;
             ByteCode = byteCode;
-            ContractName = contractName;
-        }
-        
-        protected override string GetClassNameSuffix()
-        {
-            return CLASSNAME_SUFFIX;
-        }
-
-        protected override string GetBaseName()
-        {
-            return ContractName;
         }
     }
 }

--- a/src/Nethereum.Generators/CQS/FunctionCQSMessageModel.cs
+++ b/src/Nethereum.Generators/CQS/FunctionCQSMessageModel.cs
@@ -6,24 +6,11 @@ namespace Nethereum.Generators.CQS
     public class FunctionCQSMessageModel:TypeMessageModel
     {
         public FunctionABI FunctionABI { get; }
-        public string Namespace { get; }
         
-        public string CLASSNAME_SUFFIX = "Function";
-
-        public FunctionCQSMessageModel(FunctionABI functionABI, string @namespace):base(@namespace)
+        public FunctionCQSMessageModel(FunctionABI functionABI, string @namespace):
+            base(@namespace, functionABI.Name, "Function")
         {
             FunctionABI = functionABI;
-         
-        }
-
-        protected override string GetClassNameSuffix()
-        {
-            return CLASSNAME_SUFFIX;
-        }
-
-        protected override string GetBaseName()
-        {
-            return FunctionABI.Name;
         }
     }
 }

--- a/src/Nethereum.Generators/Core/TypeMessageModel.cs
+++ b/src/Nethereum.Generators/Core/TypeMessageModel.cs
@@ -5,19 +5,20 @@ namespace Nethereum.Generators.Core
         protected CommonGenerators CommonGenerators { get; set; }
 
         public string Namespace { get; }
+        public string Name { get; }
+        public string ClassNameSuffix { get; }
 
-        protected TypeMessageModel(string @namespace)
+        protected TypeMessageModel(string @namespace, string name, string classNameSuffix)
         {
             Namespace = @namespace;
+            Name = name;
+            ClassNameSuffix = classNameSuffix;
             CommonGenerators = new CommonGenerators();
         }
 
-        protected abstract string GetClassNameSuffix();
-        protected abstract string GetBaseName();
-
         public string GetTypeName(string name)
         {
-            return $"{CommonGenerators.GenerateClassName(name)}{GetClassNameSuffix()}";
+            return $"{CommonGenerators.GenerateClassName(name)}{ClassNameSuffix}";
         }
 
         public string GetFileName(string name)
@@ -27,22 +28,22 @@ namespace Nethereum.Generators.Core
 
         public string GetVariableName(string name)
         {
-            return $"{CommonGenerators.GenerateVariableName(name)}{GetClassNameSuffix()}";
+            return $"{CommonGenerators.GenerateVariableName(name)}{ClassNameSuffix}";
         }
 
         public string GetTypeName()
         {
-            return GetTypeName(GetBaseName());
+            return GetTypeName(Name);
         }
 
         public string GetFileName()
         {
-            return GetFileName(GetBaseName());
+            return GetFileName(Name);
         }
 
         public string GetVariableName()
         {
-            return GetVariableName(GetBaseName());
+            return GetVariableName(Name);
         }
     }
 }

--- a/src/Nethereum.Generators/DTOs/EventDTOModel.cs
+++ b/src/Nethereum.Generators/DTOs/EventDTOModel.cs
@@ -6,9 +6,9 @@ namespace Nethereum.Generators.DTOs
     public class EventDTOModel:TypeMessageModel
     {
         public EventABI EventABI { get; }
-        public const string SUFFIX_NAME = "EventDTO";
-
-        public EventDTOModel(EventABI eventABI, string @namespace):base(@namespace)
+       
+        public EventDTOModel(EventABI eventABI, string @namespace)
+            :base(@namespace, eventABI.Name, "EventDTO")
         {
             EventABI = eventABI;
         }
@@ -18,14 +18,5 @@ namespace Nethereum.Generators.DTOs
             return EventABI.InputParameters != null && EventABI.InputParameters.Length > 0;
         }
 
-        protected override string GetClassNameSuffix()
-        {
-            return SUFFIX_NAME;
-        }
-
-        protected override string GetBaseName()
-        {
-            return EventABI.Name;
-        }
     }
 }

--- a/src/Nethereum.Generators/DTOs/FunctionOutputDTOModel.cs
+++ b/src/Nethereum.Generators/DTOs/FunctionOutputDTOModel.cs
@@ -5,10 +5,10 @@ namespace Nethereum.Generators.DTOs
 {
     public class FunctionOutputDTOModel: TypeMessageModel
     {
-        private const string SUFFIX_NAME = "OutputDTO";
         public FunctionABI FunctionABI { get; }
 
-        public FunctionOutputDTOModel(FunctionABI functionABI, string @namespace):base(@namespace)
+        public FunctionOutputDTOModel(FunctionABI functionABI, string @namespace)
+            :base(@namespace, functionABI.Name, "OutputDTO")
         {
             FunctionABI = functionABI;
         }
@@ -17,16 +17,6 @@ namespace Nethereum.Generators.DTOs
         {
             return FunctionABI.OutputParameters != null && FunctionABI.OutputParameters.Length > 0 &&
                    FunctionABI.Constant;
-        }
-
-        protected override string GetClassNameSuffix()
-        {
-            return SUFFIX_NAME;
-        }
-
-        protected override string GetBaseName()
-        {
-            return FunctionABI.Name;
         }
     }
 }

--- a/src/Nethereum.Generators/Service/ServiceModel.cs
+++ b/src/Nethereum.Generators/Service/ServiceModel.cs
@@ -6,32 +6,20 @@ namespace Nethereum.Generators.Service
 {
     public class ServiceModel:TypeMessageModel
     {
-        public string CLASSNAME_SUFFIX = "Service";
         public ContractABI ContractABI { get; }
-        public string ContractName { get; }
         public string CQSNamespace { get; }
         public string FunctionOutputNamespace { get; }
         public ContractDeploymentCQSMessageModel ContractDeploymentCQSMessageModel { get; }
 
         public ServiceModel(ContractABI contractABI, string contractName, 
                             string byteCode, string @namespace, 
-                            string cqsNamespace, string functionOutputNamespace):base(@namespace)
+                            string cqsNamespace, string functionOutputNamespace):
+            base(@namespace, contractName, "Service")
         {
             ContractABI = contractABI;
-            ContractName = contractName;
             CQSNamespace = cqsNamespace;
             FunctionOutputNamespace = functionOutputNamespace;
             ContractDeploymentCQSMessageModel = new ContractDeploymentCQSMessageModel(contractABI.Constructor, cqsNamespace, byteCode, contractName);
-        }
-
-        protected override string GetClassNameSuffix()
-        {
-            return CLASSNAME_SUFFIX;
-        }
-
-        protected override string GetBaseName()
-        {
-            return ContractName;
         }
     }
 }


### PR DESCRIPTION
A little re-working of the TypeMessageModel base class and sub classes - to reduce unnecessary code duplication in sub classes.