### PR TITLE
Better max int size message

### DIFF
--- a/src/Nethereum.ABI.UnitTests/IntEncodingTests.cs
+++ b/src/Nethereum.ABI.UnitTests/IntEncodingTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
@@ -198,6 +199,16 @@ namespace Nethereum.ABI.UnitTests
             uint given = 1234567;
             var result = intType.Encode(given).ToHex();
             Assert.Equal("000000000000000000000000000000000000000000000000000000000012d687", result);
+        }
+
+        [Fact]
+        public virtual void ShouldThrowErrorWhileEncodeLargeInt()
+        {
+            const int maxIntSizeInBytes = 32;
+            var intType = new IntType("uint");
+            var given = new BigInteger(Enumerable.Range(1, maxIntSizeInBytes + 1).Select(x => (byte) x).ToArray());
+            var ex = Assert.Throws<ArgumentOutOfRangeException>("value", () => intType.Encode(given));
+            Assert.StartsWith($"Integer value must not exeed maximum Solidity size of {maxIntSizeInBytes} bytes", ex.Message);
         }
 
         [Fact]

--- a/src/Nethereum.ABI.UnitTests/IntEncodingTests.cs
+++ b/src/Nethereum.ABI.UnitTests/IntEncodingTests.cs
@@ -208,7 +208,7 @@ namespace Nethereum.ABI.UnitTests
             var intType = new IntType("uint");
             var given = new BigInteger(Enumerable.Range(1, maxIntSizeInBytes + 1).Select(x => (byte) x).ToArray());
             var ex = Assert.Throws<ArgumentOutOfRangeException>("value", () => intType.Encode(given));
-            Assert.StartsWith($"Integer value must not exeed maximum Solidity size of {maxIntSizeInBytes} bytes", ex.Message);
+            Assert.StartsWith($"Integer value must not exceed maximum Solidity size of {maxIntSizeInBytes} bytes", ex.Message);
         }
 
         [Fact]

--- a/src/Nethereum.ABI/Encoders/IntTypeEncoder.cs
+++ b/src/Nethereum.ABI/Encoders/IntTypeEncoder.cs
@@ -46,7 +46,8 @@ namespace Nethereum.ABI.Encoders
                             : value.ToByteArray();
 
             if (bytes.Length > maxIntSizeInBytes)
-                throw new ArgumentOutOfRangeException(nameof(value), $"Integer value must not exeed maximum Solidity size of {maxIntSizeInBytes} bytes");
+                throw new ArgumentOutOfRangeException(nameof(value),
+                                                      $"Integer value must not exceed maximum Solidity size of {maxIntSizeInBytes} bytes. Length of passed value is {bytes.Length}");
             
             var ret = new byte[maxIntSizeInBytes];
 

--- a/src/Nethereum.ABI/Encoders/IntTypeEncoder.cs
+++ b/src/Nethereum.ABI/Encoders/IntTypeEncoder.cs
@@ -32,30 +32,31 @@ namespace Nethereum.ABI.Encoders
             return EncodeInt(bigInt);
         }
 
-        public byte[] EncodeInt(int i)
+        public byte[] EncodeInt(int value)
         {
-            return EncodeInt(new BigInteger(i));
+            return EncodeInt(new BigInteger(value));
         }
 
-        public byte[] EncodeInt(BigInteger bigInt)
+        public byte[] EncodeInt(BigInteger value)
         {
-            var ret = new byte[32];
+            const int maxIntSizeInBytes = 32;
+            //It should always be Big Endian.
+            var bytes = BitConverter.IsLittleEndian
+                            ? value.ToByteArray().Reverse().ToArray()
+                            : value.ToByteArray();
+
+            if (bytes.Length > maxIntSizeInBytes)
+                throw new ArgumentOutOfRangeException(nameof(value), $"Integer value must not exeed maximum Solidity size of {maxIntSizeInBytes} bytes");
+            
+            var ret = new byte[maxIntSizeInBytes];
 
             for (var i = 0; i < ret.Length; i++)
-                if (bigInt.Sign < 0)
+                if (value.Sign < 0)
                     ret[i] = 0xFF;
                 else
                     ret[i] = 0;
 
-            byte[] bytes;
-
-            //It should always be Big Endian.
-            if (BitConverter.IsLittleEndian)
-                bytes = bigInt.ToByteArray().Reverse().ToArray();
-            else
-                bytes = bigInt.ToByteArray().ToArray();
-
-            Array.Copy(bytes, 0, ret, 32 - bytes.Length, bytes.Length);
+            Array.Copy(bytes, 0, ret, maxIntSizeInBytes - bytes.Length, bytes.Length);
 
             return ret;
         }


### PR DESCRIPTION
This PR allows to provide better and earlier error message if user exeeds maximum Solidity integer type length