### PR TITLE
Integer Encoding and Decoding for Large Numbers

### DIFF
--- a/src/Nethereum.ABI/FunctionEncoding/ParameterDecoder.cs
+++ b/src/Nethereum.ABI/FunctionEncoding/ParameterDecoder.cs
@@ -166,6 +166,13 @@ namespace Nethereum.ABI.FunctionEncoding
                 else
                 {
                     var bytes = outputBytes.Skip(currentIndex).Take(param.ABIType.FixedSize).ToArray();
+                    if (outputParam.Parameter.ABIType.Name.Contains("uint"))
+                    {
+                        // will always be positive, append 0 byte at the front to reflect unsigned integer
+                        byte[] newArray = new byte[bytes.Length + 1];
+                        bytes.CopyTo(newArray, 1);
+                        bytes = newArray;
+                    }
                     outputParam.Result = param.ABIType.Decode(bytes, outputParam.Parameter.DecodedType);
 
                     currentIndex = currentIndex + param.ABIType.FixedSize;


### PR DESCRIPTION
Previously, while attempting to enter large numbers (e.g., max of uint) as ParamArray results in a System.ArgumentOutOfRangeException.

This is now fixed, additionally bound checks are done to ensure integer values should not overflow when using the Nethereum library.


[Unable to pass BigInteger value to contract as ParamArray.docx](https://github.com/Nethereum/Nethereum/files/2108359/Unable.to.pass.BigInteger.value.to.contract.as.ParamArray.docx)


PS: Heard you @juanfranblanco on adding the validation for all lengths of int/uint types (uint8, uint16... etc). Happy to pick this up though I admit I need to learn a lot more from everyone here, let's first see if I code decent enough through this PR to help out more... :)