### PR TITLE
Fix typo in TransactionManager

### DIFF
--- a/src/Nethereum.RPC/TransactionManagers/TransactionManager.cs
+++ b/src/Nethereum.RPC/TransactionManagers/TransactionManager.cs
@@ -18,7 +18,7 @@ namespace Nethereum.RPC.TransactionManagers
 
         public override Task<string> SignTransactionRetrievingNextNonceAsync(TransactionInput transaction)
         {
-            throw new InvalidOperationException("Default transaction manager sign offline transactions");
+            throw new InvalidOperationException("Default transaction manager cannot sign offline transactions");
         }
 
         public TransactionManager(IClient client)


### PR DESCRIPTION
While going through the source code to discover the api functionalities, I came across this class. I think there is a "cannot" missing, from the return.