### PR TITLE
HexByteConvertor: add more info if exception happens

### DIFF
--- a/src/Nethereum.Hex/HexConvertors/Extensions/HexByteConvertorExtensions.cs
+++ b/src/Nethereum.Hex/HexConvertors/Extensions/HexByteConvertorExtensions.cs
@@ -52,7 +52,7 @@ namespace Nethereum.Hex.HexConvertors.Extensions
             return ToHex(value).TrimStart('0');
         }
 
-        public static byte[] HexToByteArray(this string value)
+        private static byte[] HexToByteArrayInternal(string value)
         {
             byte[] bytes = null;
             if (string.IsNullOrEmpty(value))
@@ -93,6 +93,17 @@ namespace Nethereum.Hex.HexConvertors.Extensions
             }
 
             return bytes;
+        }
+
+        public static byte[] HexToByteArray(this string value)
+        {
+            try {
+                return HexToByteArrayInternal(value);
+            }
+            catch (Exception ex) {
+                throw new InvalidOperationException(string.Format(
+                    "String '{0}' could not be converted to byte array (not hex?).", value), ex);
+            }
         }
 
         private static byte FromCharacterToByte(char character, int index, int shift = 0)


### PR DESCRIPTION
Before adding this try-catch, it could happen that
an Nethereum HTTP request would fail with a cryptic
exception just mentioning one character instead of
the whole string that needed to be converted, such
as:

```
System.AggregateException: One or more errors occurred. ---> System.AggregateException: One or more errors occurred. ---> System.Exception: Unable to convert the result to type Nethereum.Hex.HexTypes.HexBigInteger --->
System.InvalidOperationException: Character 'n' at index '1' is not valid alphanumeric character.
  at Nethereum.Hex.HexConvertors.Extensions.HexByteConvertorExtensions.FromCharacterToByte (System.Char character, System.Int32 index, System.Int32 shift) [0x000a1] in <ae2bf6c7a6e248d6970e6b9e7de0fa61>:0
  at Nethereum.Hex.HexConvertors.Extensions.HexByteConvertorExtensions.HexToByteArray (System.String value) [0x00095] in <ae2bf6c7a6e248d6970e6b9e7de0fa61>:0
  at Nethereum.Hex.HexConvertors.Extensions.HexBigIntegerConvertorExtensions.HexToBigInteger (System.String hex, System.Boolean isHexLittleEndian) [0x00019] in <ae2bf6c7a6e248d6970e6b9e7de0fa61>:0
  at Nethereum.Hex.HexConvertors.HexBigIntegerBigEndianConvertor.ConvertFromHex (System.String hex) [0x00001] in <ae2bf6c7a6e248d6970e6b9e7de0fa61>:0
  at Nethereum.Hex.HexTypes.HexRPCType`1[T].ConvertFromHex (System.String newHexValue) [0x00001] in <ae2bf6c7a6e248d6970e6b9e7de0fa61>:0
  at Nethereum.Hex.HexTypes.HexRPCType`1[T].InitialiseFromHex (System.String newHexValue) [0x00001] in <ae2bf6c7a6e248d6970e6b9e7de0fa61>:0
  at Nethereum.Hex.HexTypes.HexRPCType`1[T]..ctor (Nethereum.Hex.HexConvertors.IHexConvertor`1[T] convertor, System.String hexValue) [0x0000f] in <ae2bf6c7a6e248d6970e6b9e7de0fa61>:0
  at Nethereum.Hex.HexTypes.HexBigInteger..ctor (System.String hex) [0x00006] in <ae2bf6c7a6e248d6970e6b9e7de0fa61>:0
  at Nethereum.Hex.HexTypes.HexTypeFactory.CreateFromHex[T] (System.String hex) [0x0001b] in <ae2bf6c7a6e248d6970e6b9e7de0fa61>:0
  at Nethereum.Hex.HexTypes.HexRPCTypeJsonConverter`2[T,TValue].ReadJson (Newtonsoft.Json.JsonReader reader, System.Type objectType, System.Object existingValue, Newtonsoft.Json.JsonSerializer serializer) [0x00007] in <ae2bf6c7a6e248d6970e6b9e7de0fa61>:0
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable (Newtonsoft.Json.JsonConverter converter, Newtonsoft.Json.JsonReader reader, System.Type objectType, System.Object existingValue) [0x00055] in <d32db49e5e3440729da31845c03ddc3a>:0
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize (Newtonsoft.Json.JsonReader reader, System.Type objectType, System.Boolean checkAdditionalContent) [0x000db] in <d32db49e5e3440729da31845c03ddc3a>:0
  at Newtonsoft.Json.JsonSerializer.DeserializeInternal (Newtonsoft.Json.JsonReader reader, System.Type objectType) [0x00054] in <d32db49e5e3440729da31845c03ddc3a>:0
  at Newtonsoft.Json.JsonSerializer.Deserialize (Newtonsoft.Json.JsonReader reader, System.Type objectType) [0x00000] in <d32db49e5e3440729da31845c03ddc3a>:0
  at Newtonsoft.Json.Linq.JToken.ToObject (System.Type objectType, Newtonsoft.Json.JsonSerializer jsonSerializer) [0x00012] in <d32db49e5e3440729da31845c03ddc3a>:0
  at Newtonsoft.Json.Linq.JToken.ToObject (System.Type objectType) [0x002ff] in <d32db49e5e3440729da31845c03ddc3a>:0
  at Newtonsoft.Json.Linq.JToken.ToObject[T] () [0x00000] in <d32db49e5e3440729da31845c03ddc3a>:0
  at Nethereum.JsonRpc.Client.RpcMessages.RpcResponseExtensions.GetResult[T] (Nethereum.JsonRpc.Client.RpcMessages.RpcResponseMessage response, System.Boolean returnDefaultIfNull, Newtonsoft.Json.JsonSerializerSettings settings) [0x00064] in <3746e19577174f67a740fdc380b7f6d5>:0
  --- End of inner exception stack trace ---
  at Nethereum.JsonRpc.Client.RpcMessages.RpcResponseExtensions.GetResult[T] (Nethereum.JsonRpc.Client.RpcMessages.RpcResponseMessage response, System.Boolean returnDefaultIfNull, Newtonsoft.Json.JsonSerializerSettings settings) [0x000a3] in <3746e19577174f67a740fdc380b7f6d5>:0
  at Nethereum.JsonRpc.Client.RpcClient+<SendInnerRequestAync>d__12`1[T].MoveNext () [0x000d4] in <87ef363b667b4793b1dc5501fa8a6c18>:0
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/runtime/exceptionservices/exceptionservicescommon.cs:152
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x00037] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:187
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:156
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:128
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:535
  at Nethereum.JsonRpc.Client.ClientBase+<SendRequestAsync>d__8`1[T].MoveNext () [0x0014f] in <3746e19577174f67a740fdc380b7f6d5>:0
  --- End of inner exception stack trace ---
  at System.Threading.Tasks.Task.ThrowIfExceptional (System.Boolean includeTaskCanceledExceptions) [0x00011] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:2164
  at System.Threading.Tasks.Task.Wait (System.Int32 millisecondsTimeout, System.Threading.CancellationToken cancellationToken) [0x00043] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:3196
  at System.Threading.Tasks.Task.Wait () [0x00000] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:3061
  at GWallet.Backend.Ether.Server+GetConfirmedEtherBalanceInternal@237.Invoke () [0x00064] in /Users/andres/Documents/Code/gwalletFRONTEND/src/GWallet.Backend/Ether/EtherServer.fs:251
  at System.Threading.Tasks.Task`1[TResult].InnerInvoke () [0x0000f] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/threading/Tasks/Future.cs:680
  at System.Threading.Tasks.Task.Execute () [0x00010] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:2509
  --- End of inner exception stack trace ---
  at System.Threading.Tasks.Task.ThrowIfExceptional (System.Boolean includeTaskCanceledExceptions) [0x00011] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:2164
  at System.Threading.Tasks.Task.Wait (System.Int32 millisecondsTimeout, System.Threading.CancellationToken cancellationToken) [0x00043] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:3196
  at System.Threading.Tasks.Task.Wait (System.TimeSpan timeout) [0x00022] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.12.0.4/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/threading/Tasks/Task.cs:3095
(...)
```