### PR TITLE
Hex,JsonRpc: throw more proper exceptions if invalid format is found

### DIFF
--- a/src/Nethereum.Hex/HexConvertors/Extensions/HexByteConvertorExtensions.cs
+++ b/src/Nethereum.Hex/HexConvertors/Extensions/HexByteConvertorExtensions.cs
@@ -100,8 +100,9 @@ namespace Nethereum.Hex.HexConvertors.Extensions
             try {
                 return HexToByteArrayInternal(value);
             }
-            catch (Exception ex) {
-                throw new InvalidOperationException(string.Format(
+            catch (FormatException ex)
+            {
+                throw new FormatException(string.Format(
                     "String '{0}' could not be converted to byte array (not hex?).", value), ex);
             }
         }
@@ -123,7 +124,7 @@ namespace Nethereum.Hex.HexConvertors.Extensions
             }
             else
             {
-                throw new InvalidOperationException(string.Format(
+                throw new FormatException(string.Format(
                     "Character '{0}' at index '{1}' is not valid alphanumeric character.", character, index));
             }
 

--- a/src/Nethereum.JsonRpc.Client/ClientBase.cs
+++ b/src/Nethereum.JsonRpc.Client/ClientBase.cs
@@ -16,9 +16,9 @@ namespace Nethereum.JsonRpc.Client
             if (OverridingRequestInterceptor != null)
                 return
                     (T)
-                    await OverridingRequestInterceptor.InterceptSendRequestAsync(SendInnerRequestAync<T>, request, route)
+                    await OverridingRequestInterceptor.InterceptSendRequestAsync(SendInnerRequestAsync<T>, request, route)
                         .ConfigureAwait(false);
-            return await SendInnerRequestAync<T>(request, route).ConfigureAwait(false);
+            return await SendInnerRequestAsync<T>(request, route).ConfigureAwait(false);
         }
 
         public async Task<T> SendRequestAsync<T>(string method, string route = null, params object[] paramList)
@@ -26,17 +26,17 @@ namespace Nethereum.JsonRpc.Client
             if (OverridingRequestInterceptor != null)
                 return
                     (T)
-                    await OverridingRequestInterceptor.InterceptSendRequestAsync(SendInnerRequestAync<T>, method, route,
+                    await OverridingRequestInterceptor.InterceptSendRequestAsync(SendInnerRequestAsync<T>, method, route,
                         paramList).ConfigureAwait(false);
-            return await SendInnerRequestAync<T>(method, route, paramList).ConfigureAwait(false);
+            return await SendInnerRequestAsync<T>(method, route, paramList).ConfigureAwait(false);
         }
 
         public abstract Task SendRequestAsync(RpcRequest request, string route = null);
         public abstract Task SendRequestAsync(string method, string route = null, params object[] paramList);
 
-        protected abstract Task<T> SendInnerRequestAync<T>(RpcRequest request, string route = null);
+        protected abstract Task<T> SendInnerRequestAsync<T>(RpcRequest request, string route = null);
 
-        protected abstract Task<T> SendInnerRequestAync<T>(string method, string route = null,
+        protected abstract Task<T> SendInnerRequestAsync<T>(string method, string route = null,
             params object[] paramList);
     }
 }

--- a/src/Nethereum.JsonRpc.Client/RPCResponseException.cs
+++ b/src/Nethereum.JsonRpc.Client/RPCResponseException.cs
@@ -11,4 +11,12 @@ namespace Nethereum.JsonRpc.Client
 
         public RpcError RpcError { get; }
     }
+
+    public class RpcResponseFormatException : Exception
+    {
+        public RpcResponseFormatException(string message, FormatException innerException)
+            : base(message, innerException)
+        {
+        }
+    }
 }

--- a/src/Nethereum.JsonRpc.Client/RpcMessages/RpcMessages.cs
+++ b/src/Nethereum.JsonRpc.Client/RpcMessages/RpcMessages.cs
@@ -64,6 +64,10 @@ SOFTWARE.
                     return response.Result.ToObject<T>(jsonSerializer);
                 }
             }
+            catch (FormatException ex)
+            {
+                throw new FormatException("Invalid format when trying to convert the result to type " + typeof(T), ex);
+            }
             catch (Exception ex)
             {
                 throw new Exception("Unable to convert the result to type " + typeof(T), ex);

--- a/src/Nethereum.JsonRpc.IpcClient/IpcClientBase.cs
+++ b/src/Nethereum.JsonRpc.IpcClient/IpcClientBase.cs
@@ -25,7 +25,7 @@ namespace Nethereum.JsonRpc.IpcClient
 
         public JsonSerializerSettings JsonSerializerSettings { get; set; }
 
-        protected override async Task<T> SendInnerRequestAync<T>(RpcRequest request, string route = null)
+        protected override async Task<T> SendInnerRequestAsync<T>(RpcRequest request, string route = null)
         {
             var response =
                 await SendAsync<RpcRequestMessage, RpcResponseMessage>(
@@ -35,7 +35,7 @@ namespace Nethereum.JsonRpc.IpcClient
             return response.GetResult<T>();
         }
 
-        protected override async Task<T> SendInnerRequestAync<T>(string method, string route = null,
+        protected override async Task<T> SendInnerRequestAsync<T>(string method, string route = null,
             params object[] paramList)
         {
             var response =

--- a/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
+++ b/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
@@ -38,7 +38,7 @@ namespace Nethereum.JsonRpc.Client
             CreateNewHttpClient();
         }
 
-        protected override async Task<T> SendInnerRequestAync<T>(RpcRequest request, string route = null)
+        protected override async Task<T> SendInnerRequestAsync<T>(RpcRequest request, string route = null)
         {
             var response =
                 await SendAsync(
@@ -48,7 +48,7 @@ namespace Nethereum.JsonRpc.Client
             return response.GetResult<T>();
         }
 
-        protected override async Task<T> SendInnerRequestAync<T>(string method, string route = null,
+        protected override async Task<T> SendInnerRequestAsync<T>(string method, string route = null,
             params object[] paramList)
         {
             var request = new RpcRequestMessage(Guid.NewGuid().ToString(), method, paramList);

--- a/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
+++ b/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
@@ -43,7 +43,14 @@ namespace Nethereum.JsonRpc.Client
         {
             var response = await SendAsync(reqMsg, route).ConfigureAwait(false);
             HandleRpcError(response);
-            return response.GetResult<T>();
+            try
+            {
+                return response.GetResult<T>();
+            }
+            catch(FormatException formatException)
+            {
+                throw new RpcResponseFormatException("Invalid format found in RPC response", formatException);
+            }
         }
 
         protected override async Task<T> SendInnerRequestAsync<T>(RpcRequest request, string route = null)

--- a/src/Nethereum.JsonRpc.RpcClient/SimpleRpcClient.cs
+++ b/src/Nethereum.JsonRpc.RpcClient/SimpleRpcClient.cs
@@ -24,7 +24,7 @@ namespace Nethereum.JsonRpc.Client
             _httpClient.BaseAddress = baseUrl;
         }
 
-        protected override async Task<T> SendInnerRequestAync<T>(RpcRequest request, string route = null)
+        protected override async Task<T> SendInnerRequestAsync<T>(RpcRequest request, string route = null)
         {
             var response =
                 await SendAsync(
@@ -34,7 +34,7 @@ namespace Nethereum.JsonRpc.Client
             return response.GetResult<T>();
         }
 
-        protected override async Task<T> SendInnerRequestAync<T>(string method, string route = null,
+        protected override async Task<T> SendInnerRequestAsync<T>(string method, string route = null,
             params object[] paramList)
         {
             var request = new RpcRequestMessage(Guid.NewGuid().ToString(), method, paramList);

--- a/src/Nethereum.JsonRpc.WebSocketClient/WebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/WebSocketClient.cs
@@ -28,7 +28,7 @@ namespace Nethereum.JsonRpc.WebSocketClient
 
         public JsonSerializerSettings JsonSerializerSettings { get; set; }
 
-        protected override async Task<T> SendInnerRequestAync<T>(RpcRequest request, string route = null)
+        protected override async Task<T> SendInnerRequestAsync<T>(RpcRequest request, string route = null)
         {
             var response =
                 await SendAsync<RpcRequestMessage, RpcResponseMessage>(
@@ -38,7 +38,7 @@ namespace Nethereum.JsonRpc.WebSocketClient
             return response.GetResult<T>();
         }
 
-        protected override async Task<T> SendInnerRequestAync<T>(string method, string route = null,
+        protected override async Task<T> SendInnerRequestAsync<T>(string method, string route = null,
             params object[] paramList)
         {
             var response =


### PR DESCRIPTION
* Instead of InvalidOperationException, use FormatException.
* Instead of throwing generic (and not catchable)System.Exception,
throw a new typed Rpc-prefixed exception.

This is so that Nethereum consumers can catch faulty responses
from buggy servers, like demonstrated in:
https://github.com/Nethereum/Nethereum/pull/380#issuecomment-415718890