### PR TITLE
Enforce azure signature to a low S

### DIFF
--- a/src/Nethereum.Signer.AzureKeyVault/AzureKeyVaultExternalSigner.cs
+++ b/src/Nethereum.Signer.AzureKeyVault/AzureKeyVaultExternalSigner.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
 using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault;
-using Nethereum.RLP;
 using Nethereum.Signer.Crypto;
 
 namespace Nethereum.Signer.AzureKeyVault
@@ -40,7 +36,7 @@ namespace Nethereum.Signer.AzureKeyVault
         {
             var keyOperationResult = await KeyVaultClient.SignAsync(VaultUrl, "ECDSA256", hash);
             var signature = keyOperationResult.Result;
-            return ECDSASignatureFactory.FromComponents(signature);
+            return ECDSASignatureFactory.FromComponents(signature).MakeCanonical();
         }
 
         public override async Task SignAsync(Transaction transaction)


### PR DESCRIPTION
I spent days trying to figure out why I was getting intermittent transaction failures both from the azure blockchain and even my local chain - I thought I was going crazy. I was finally able to track down the source of all my headaches to an Azure signature not enforcing a low S and in turn when a high S signature was generated, the transaction would fail with "invalid sender".

This changes makes sure the azure signatures have a low S all the time.