### PR TITLE
Clean up CSharp code generation formatting

### DIFF
--- a/src/Nethereum.Generators/CQS/CSharp/ContractDeploymentCQSMessageCSharpTemplate.cs
+++ b/src/Nethereum.Generators/CQS/CSharp/ContractDeploymentCQSMessageCSharpTemplate.cs
@@ -20,15 +20,11 @@ namespace Nethereum.Generators.CQS
             return
                 $@"{GetPartialMainClass()}
 
-{SpaceUtils.OneTab}public class {typeName}Base:ContractDeploymentMessage
+{SpaceUtils.OneTab}public class {typeName}Base : ContractDeploymentMessage
 {SpaceUtils.OneTab}{{
-{SpaceUtils.TwoTabs}
 {SpaceUtils.TwoTabs}public static string BYTECODE = ""{Model.ByteCode}"";
-{SpaceUtils.TwoTabs}
-{SpaceUtils.TwoTabs}public {typeName}Base():base(BYTECODE) {{ }}
-{SpaceUtils.TwoTabs}
-{SpaceUtils.TwoTabs}public {typeName}Base(string byteCode):base(byteCode) {{ }}
-{SpaceUtils.TwoTabs}
+{SpaceUtils.TwoTabs}public {typeName}Base() : base(BYTECODE) {{ }}
+{SpaceUtils.TwoTabs}public {typeName}Base(string byteCode) : base(byteCode) {{ }}
 {_parameterAbiFunctionDtocSharpTemplate.GenerateAllProperties(Model.ConstructorABI.InputParameters)}
 {SpaceUtils.OneTab}}}";
         }
@@ -37,11 +33,10 @@ namespace Nethereum.Generators.CQS
         {
             var typeName = Model.GetTypeName();
 
-            return $@"{SpaceUtils.OneTab}public partial class {typeName}:{typeName}Base
+            return $@"{SpaceUtils.OneTab}public partial class {typeName} : {typeName}Base
 {SpaceUtils.OneTab}{{
-{SpaceUtils.TwoTabs}public {typeName}():base(BYTECODE) {{ }}
-{SpaceUtils.TwoTabs}
-{SpaceUtils.TwoTabs}public {typeName}(string byteCode):base(byteCode) {{ }}
+{SpaceUtils.TwoTabs}public {typeName}() : base(BYTECODE) {{ }}
+{SpaceUtils.TwoTabs}public {typeName}(string byteCode) : base(byteCode) {{ }}
 {SpaceUtils.OneTab}}}";
         }
     }

--- a/src/Nethereum.Generators/CQS/CSharp/FunctionCQSMessageCSharpTemplate.cs
+++ b/src/Nethereum.Generators/CQS/CSharp/FunctionCQSMessageCSharpTemplate.cs
@@ -40,7 +40,7 @@ namespace Nethereum.Generators.CQS
             return $@"{GetPartialMainClass()}
 
 {header}
-{SpaceUtils.OneTab}public class {Model.GetTypeName()}Base:FunctionMessage
+{SpaceUtils.OneTab}public class {Model.GetTypeName()}Base : FunctionMessage
 {SpaceUtils.OneTab}{{
 {_parameterAbiFunctionDtocSharpTemplate.GenerateAllProperties(functionABI.InputParameters)}
 {SpaceUtils.OneTab}}}";
@@ -48,8 +48,7 @@ namespace Nethereum.Generators.CQS
 
         public string GetPartialMainClass()
         {
-            return $@"{SpaceUtils.OneTab}public partial class {Model.GetTypeName()}:{Model.GetTypeName()}Base{{}}";
-
-        }           
+            return $@"{SpaceUtils.OneTab}public partial class {Model.GetTypeName()} : {Model.GetTypeName()}Base {{ }}";
+        }
     }
 }

--- a/src/Nethereum.Generators/Core/CSharpMultipleClassFileTemplate.cs
+++ b/src/Nethereum.Generators/Core/CSharpMultipleClassFileTemplate.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Nethereum.Generators.Core;
 
 namespace Nethereum.Generators.CQS
@@ -20,6 +22,7 @@ namespace Nethereum.Generators.CQS
         {
             return
                 $@"{GenerateNamespaceDependencies()}
+{SpaceUtils.NoTabs}
 {SpaceUtils.NoTabs}namespace {FileModel.Namespace}
 {SpaceUtils.NoTabs}{{
 {GenerateAll()}
@@ -29,16 +32,7 @@ namespace Nethereum.Generators.CQS
 
         protected string GenerateAll()
         {
-            var result = "";
-            foreach (var classGenerator in ClassGenerators)
-            {
-                result = result +
-$@"{SpaceUtils.OneTab}
-{SpaceUtils.OneTab}
-{classGenerator.GenerateClass()}";
-            }
-
-            return result;
+            return string.Join($"{Environment.NewLine}{Environment.NewLine}", ClassGenerators.Select(x => x.GenerateClass()));
         }
     }
 

--- a/src/Nethereum.Generators/Core/CsharpClassFileTemplate.cs
+++ b/src/Nethereum.Generators/Core/CsharpClassFileTemplate.cs
@@ -22,6 +22,7 @@ namespace Nethereum.Generators.CQS
         {
             return
                 $@"{GenerateNamespaceDependencies()}
+{SpaceUtils.NoTabs}
 {SpaceUtils.NoTabs}namespace {ClassModel.Namespace}
 {SpaceUtils.NoTabs}{{
 {SpaceUtils.NoTabs}{ClassTemplate.GenerateClass()}

--- a/src/Nethereum.Generators/DTOs/CSharp/EventDTOCSharpTemplate.cs
+++ b/src/Nethereum.Generators/DTOs/CSharp/EventDTOCSharpTemplate.cs
@@ -21,7 +21,7 @@ namespace Nethereum.Generators.DTOs
                     $@"{GetPartialMainClass()}
 
 {SpaceUtils.OneTab}[Event(""{Model.EventABI.Name}"")]
-{SpaceUtils.OneTab}public class {Model.GetTypeName()}Base: IEventDTO
+{SpaceUtils.OneTab}public class {Model.GetTypeName()}Base : IEventDTO
 {SpaceUtils.OneTab}{{
 {_parameterAbiEventDtocSharpTemplate.GenerateAllProperties(Model.EventABI.InputParameters)}
 {SpaceUtils.OneTab}}}";
@@ -31,7 +31,7 @@ namespace Nethereum.Generators.DTOs
 
         public string GetPartialMainClass()
         {
-            return $@"{SpaceUtils.OneTab}public partial class {Model.GetTypeName()}:{Model.GetTypeName()}Base{{}}";
+            return $@"{SpaceUtils.OneTab}public partial class {Model.GetTypeName()} : {Model.GetTypeName()}Base {{ }}";
         }
     }
 }

--- a/src/Nethereum.Generators/DTOs/CSharp/FunctionOutputDTOCSharpTemplate.cs
+++ b/src/Nethereum.Generators/DTOs/CSharp/FunctionOutputDTOCSharpTemplate.cs
@@ -21,7 +21,7 @@ namespace Nethereum.Generators.DTOs
                     $@"{GetPartialMainClass()}
 
 {SpaceUtils.OneTab}[FunctionOutput]
-{SpaceUtils.OneTab}public class {Model.GetTypeName()}Base :IFunctionOutputDTO 
+{SpaceUtils.OneTab}public class {Model.GetTypeName()}Base : IFunctionOutputDTO 
 {SpaceUtils.OneTab}{{
 {_parameterAbiFunctionDtocSharpTemplate.GenerateAllProperties(Model.FunctionABI.OutputParameters)}
 {SpaceUtils.OneTab}}}";
@@ -31,7 +31,7 @@ namespace Nethereum.Generators.DTOs
 
         public string GetPartialMainClass()
         {
-            return $@"{SpaceUtils.OneTab}public partial class {Model.GetTypeName()}:{Model.GetTypeName()}Base{{}}";
+            return $@"{SpaceUtils.OneTab}public partial class {Model.GetTypeName()} : {Model.GetTypeName()}Base {{ }}";
         }
     }
 }

--- a/src/Nethereum.Generators/DTOs/CSharp/ParameterABIEventDTOCSharpTemplate.cs
+++ b/src/Nethereum.Generators/DTOs/CSharp/ParameterABIEventDTOCSharpTemplate.cs
@@ -27,7 +27,7 @@ namespace Nethereum.Generators.DTOs
             var parameterModel = new ParameterABIModel(parameter);
             return
                 $@"{SpaceUtils.TwoTabs}[Parameter(""{parameter.Type}"", ""{@parameter.Name}"", {parameter.Order}, {utils.GetBooleanAsString(parameter.Indexed)} )]
-{SpaceUtils.TwoTabs}public virtual {parameterAbiModelTypeMap.GetParameterDotNetOutputMapType(parameter)} {parameterModel.GetPropertyName()} {{get; set;}}";
+{SpaceUtils.TwoTabs}public virtual {parameterAbiModelTypeMap.GetParameterDotNetOutputMapType(parameter)} {parameterModel.GetPropertyName()} {{ get; set; }}";
         }
     }
 }

--- a/src/Nethereum.Generators/DTOs/CSharp/ParameterABIFunctionDTOCsharpTemplate.cs
+++ b/src/Nethereum.Generators/DTOs/CSharp/ParameterABIFunctionDTOCsharpTemplate.cs
@@ -13,7 +13,7 @@ namespace Nethereum.Generators.DTOs
         public ParameterABIFunctionDTOCSharpTemplate()
         {
             var typeMapper = new ABITypeToCSharpType();
-            parameterAbiModelTypeMap = new ParameterABIModelTypeMap(typeMapper);    
+            parameterAbiModelTypeMap = new ParameterABIModelTypeMap(typeMapper);
         }
 
         public string GenerateAllProperties(ParameterABI[] parameters)
@@ -26,7 +26,7 @@ namespace Nethereum.Generators.DTOs
             var parameterModel = new ParameterABIModel(parameter);
             return 
                 $@"{SpaceUtils.TwoTabs}[Parameter(""{parameter.Type}"", ""{@parameter.Name}"", {parameter.Order})]
-{SpaceUtils.TwoTabs}public virtual {parameterAbiModelTypeMap.GetParameterDotNetOutputMapType(parameter)} {parameterModel.GetPropertyName()} {{get; set;}}";
+{SpaceUtils.TwoTabs}public virtual {parameterAbiModelTypeMap.GetParameterDotNetOutputMapType(parameter)} {parameterModel.GetPropertyName()} {{ get; set; }}";
         }
 
         public string GenerateAllFunctionParameters(ParameterABI[] parameters)

--- a/src/Nethereum.Generators/Service/CSharp/ContractDeploymentServiceMethodsCSharpTemplate.cs
+++ b/src/Nethereum.Generators/Service/CSharp/ContractDeploymentServiceMethodsCSharpTemplate.cs
@@ -40,7 +40,7 @@ namespace Nethereum.Generators.Service
 {SpaceUtils.ThreeTabs}return new {_serviceModel.GetTypeName()}(web3, receipt.ContractAddress);
 {SpaceUtils.TwoTabs}}}";
 
-            return String.Join(Environment.NewLine,sendRequestReceipt, sendRequest, sendRequestContract);
+            return string.Join($"{Environment.NewLine}{Environment.NewLine}", sendRequestReceipt, sendRequest, sendRequestContract);
         }
     }
 }

--- a/src/Nethereum.Generators/Service/CSharp/FunctionServiceMethodCSharpTemplate.cs
+++ b/src/Nethereum.Generators/Service/CSharp/FunctionServiceMethodCSharpTemplate.cs
@@ -29,8 +29,7 @@ namespace Nethereum.Generators.Service
         }
 
         public string GenerateMethod(FunctionABI functionABI)
-        { 
-
+        {
             var functionCQSMessageModel = new FunctionCQSMessageModel(functionABI, _model.CQSNamespace);
             var functionOutputDTOModel = new FunctionOutputDTOModel(functionABI, _model.FunctionOutputNamespace);
             var functionABIModel = new FunctionABIModel(functionABI, _typeConvertor);
@@ -41,9 +40,8 @@ namespace Nethereum.Generators.Service
 
             if (functionABIModel.IsMultipleOutput() && !functionABIModel.IsTransaction())
             {
-
                 var functionOutputDTOType = functionOutputDTOModel.GetTypeName();
-            
+
                 var returnWithInputParam =
 $@"{SpaceUtils.TwoTabs}public Task<{functionOutputDTOType}> {functionNameUpper}QueryAsync({messageType} {messageVariableName}, BlockParameter blockParameter = null)
 {SpaceUtils.TwoTabs}{{
@@ -51,15 +49,13 @@ $@"{SpaceUtils.TwoTabs}public Task<{functionOutputDTOType}> {functionNameUpper}Q
 {SpaceUtils.TwoTabs}}}";
 
                 var returnWithoutInputParam =
-                    $@"{SpaceUtils.TwoTabs}
-{SpaceUtils.TwoTabs}public Task<{functionOutputDTOType}> {functionNameUpper}QueryAsync(BlockParameter blockParameter = null)
+$@"{SpaceUtils.TwoTabs}public Task<{functionOutputDTOType}> {functionNameUpper}QueryAsync(BlockParameter blockParameter = null)
 {SpaceUtils.TwoTabs}{{
 {SpaceUtils.ThreeTabs}return ContractHandler.QueryDeserializingToObjectAsync<{messageType}, {functionOutputDTOType}>(null, blockParameter);
 {SpaceUtils.TwoTabs}}}";
 
                 var returnWithSimpleParams =
-                    $@"{SpaceUtils.TwoTabs}
-{SpaceUtils.TwoTabs}public Task<{functionOutputDTOType}> {functionNameUpper}QueryAsync({_parameterAbiFunctionDtocSharpTemplate.GenerateAllFunctionParameters(functionABIModel.FunctionABI.InputParameters)}, BlockParameter blockParameter = null)
+$@"{SpaceUtils.TwoTabs}public Task<{functionOutputDTOType}> {functionNameUpper}QueryAsync({_parameterAbiFunctionDtocSharpTemplate.GenerateAllFunctionParameters(functionABIModel.FunctionABI.InputParameters)}, BlockParameter blockParameter = null)
 {SpaceUtils.TwoTabs}{{
 {SpaceUtils.ThreeTabs}var {messageVariableName} = new {messageType}();
 {_parameterAbiFunctionDtocSharpTemplate.GenerateAssigmentFunctionParametersToProperties(functionABIModel.FunctionABI.InputParameters, messageVariableName, SpaceUtils.FourTabs)}
@@ -69,11 +65,11 @@ $@"{SpaceUtils.TwoTabs}public Task<{functionOutputDTOType}> {functionNameUpper}Q
 
                 if (functionABIModel.HasNoInputParameters())
                 {
-                    return returnWithInputParam + GenerateLineBreak() + returnWithoutInputParam + GenerateLineBreak();
+                    return returnWithInputParam + GenerateLineBreak() + returnWithoutInputParam;
                 }
                 else
                 {
-                    return returnWithInputParam + GenerateLineBreak() + returnWithSimpleParams + GenerateLineBreak();
+                    return returnWithInputParam + GenerateLineBreak() + returnWithSimpleParams;
                 }
             }
 
@@ -109,11 +105,11 @@ $@"{SpaceUtils.TwoTabs}public Task<{functionOutputDTOType}> {functionNameUpper}Q
 
                 if (functionABIModel.HasNoInputParameters())
                 {
-                    return returnWithInputParam + GenerateLineBreak() + returnWithoutInputParam + GenerateLineBreak();
+                    return returnWithInputParam + GenerateLineBreak() + returnWithoutInputParam;
                 }
                 else
                 {
-                    return returnWithInputParam + GenerateLineBreak() + returnWithSimpleParams + GenerateLineBreak();
+                    return returnWithInputParam + GenerateLineBreak() + returnWithSimpleParams;
                 }
             }
 

--- a/src/Nethereum.Generators/Service/CSharp/ServiceCSharpTemplate.cs
+++ b/src/Nethereum.Generators/Service/CSharp/ServiceCSharpTemplate.cs
@@ -17,25 +17,22 @@ namespace Nethereum.Generators.Service
         public override string GenerateClass()
         {
             return
-                $@"
-{SpaceUtils.OneTab}public partial class {Model.GetTypeName()}
+                $@"{SpaceUtils.OneTab}public partial class {Model.GetTypeName()}
 {SpaceUtils.OneTab}{{
-{SpaceUtils.OneTab}
 {_deploymentServiceMethodsCSharpTemplate.GenerateMethods()}
-{SpaceUtils.OneTab}
+{SpaceUtils.NoTabs}
 {SpaceUtils.TwoTabs}protected Nethereum.Web3.Web3 Web3{{ get; }}
-{SpaceUtils.TwoTabs}
+{SpaceUtils.NoTabs}
 {SpaceUtils.TwoTabs}public ContractHandler ContractHandler {{ get; }}
-{SpaceUtils.TwoTabs}
+{SpaceUtils.NoTabs}
 {SpaceUtils.TwoTabs}public {Model.GetTypeName()}(Nethereum.Web3.Web3 web3, string contractAddress)
 {SpaceUtils.TwoTabs}{{
 {SpaceUtils.ThreeTabs}Web3 = web3;
 {SpaceUtils.ThreeTabs}ContractHandler = web3.Eth.GetContractHandler(contractAddress);
 {SpaceUtils.TwoTabs}}}
-{SpaceUtils.OneTab}
+{SpaceUtils.NoTabs}
 {_functionServiceMethodCSharpTemplate.GenerateMethods()}
 {SpaceUtils.OneTab}}}";
-           
         }
     }
 }


### PR DESCRIPTION
This provides purely aesthetic changes to the code generated by the CSharp generator. Primarily removes extra whitespace and new lines that were auto-generated to help with those pesky lint errors.