### PR TITLE
Fix unit tests failing from formatting changes

### DIFF
--- a/src/Nethereum.Generators.UnitTests/Expectations/Content/CSharp/ContractDeploymentCqsMessage.01.csharp.txt
+++ b/src/Nethereum.Generators.UnitTests/Expectations/Content/CSharp/ContractDeploymentCqsMessage.01.csharp.txt
@@ -5,25 +5,21 @@ using System.Numerics;
 using Nethereum.Hex.HexTypes;
 using Nethereum.Contracts;
 using Nethereum.ABI.FunctionEncoding.Attributes;
+
 namespace DefaultNamespace
 {
-    public partial class StandardContractDeployment:StandardContractDeploymentBase
+    public partial class StandardContractDeployment : StandardContractDeploymentBase
     {
-        public StandardContractDeployment():base(BYTECODE) { }
-        
-        public StandardContractDeployment(string byteCode):base(byteCode) { }
+        public StandardContractDeployment() : base(BYTECODE) { }
+        public StandardContractDeployment(string byteCode) : base(byteCode) { }
     }
 
-    public class StandardContractDeploymentBase:ContractDeploymentMessage
+    public class StandardContractDeploymentBase : ContractDeploymentMessage
     {
-        
         public static string BYTECODE = "0x123456789";
-        
-        public StandardContractDeploymentBase():base(BYTECODE) { }
-        
-        public StandardContractDeploymentBase(string byteCode):base(byteCode) { }
-        
+        public StandardContractDeploymentBase() : base(BYTECODE) { }
+        public StandardContractDeploymentBase(string byteCode) : base(byteCode) { }
         [Parameter("uint256", "totalSupply", 1)]
-        public virtual BigInteger TotalSupply {get; set;}
+        public virtual BigInteger TotalSupply { get; set; }
     }
 }

--- a/src/Nethereum.Generators.UnitTests/Expectations/Content/CSharp/EventDTO.01.csharp.txt
+++ b/src/Nethereum.Generators.UnitTests/Expectations/Content/CSharp/EventDTO.01.csharp.txt
@@ -4,14 +4,15 @@ using System.Collections.Generic;
 using System.Numerics;
 using Nethereum.Hex.HexTypes;
 using Nethereum.ABI.FunctionEncoding.Attributes;
+
 namespace DefaultNamespace
 {
-    public partial class ItemAddedEventDTO:ItemAddedEventDTOBase{}
+    public partial class ItemAddedEventDTO : ItemAddedEventDTOBase { }
 
     [Event("ItemAdded")]
-    public class ItemAddedEventDTOBase: IEventDTO
+    public class ItemAddedEventDTOBase : IEventDTO
     {
         [Parameter("uint256", "itemId", 1, false )]
-        public virtual BigInteger ItemId {get; set;}
+        public virtual BigInteger ItemId { get; set; }
     }
 }

--- a/src/Nethereum.Generators.UnitTests/Expectations/Content/CSharp/FunctionCQSMessage.01.csharp.txt
+++ b/src/Nethereum.Generators.UnitTests/Expectations/Content/CSharp/FunctionCQSMessage.01.csharp.txt
@@ -6,14 +6,15 @@ using Nethereum.Hex.HexTypes;
 using Nethereum.Contracts;
 using Nethereum.ABI.FunctionEncoding.Attributes;
 using FunctionOutput;
+
 namespace DefaultNamespace
 {
-    public partial class BaseStatsFunction:BaseStatsFunctionBase{}
+    public partial class BaseStatsFunction : BaseStatsFunctionBase { }
 
     [Function("BaseStats", "uint256")]
-    public class BaseStatsFunctionBase:FunctionMessage
+    public class BaseStatsFunctionBase : FunctionMessage
     {
         [Parameter("uint256", "_number", 1)]
-        public virtual BigInteger Number {get; set;}
+        public virtual BigInteger Number { get; set; }
     }
 }

--- a/src/Nethereum.Generators.UnitTests/Expectations/Content/CSharp/FunctionOutputDTO.01.csharp.txt
+++ b/src/Nethereum.Generators.UnitTests/Expectations/Content/CSharp/FunctionOutputDTO.01.csharp.txt
@@ -4,16 +4,17 @@ using System.Collections.Generic;
 using System.Numerics;
 using Nethereum.Hex.HexTypes;
 using Nethereum.ABI.FunctionEncoding.Attributes;
+
 namespace DefaultNamespace
 {
-    public partial class GetCarOutputDTO:GetCarOutputDTOBase{}
+    public partial class GetCarOutputDTO : GetCarOutputDTOBase { }
 
     [FunctionOutput]
-    public class GetCarOutputDTOBase :IFunctionOutputDTO 
+    public class GetCarOutputDTOBase : IFunctionOutputDTO 
     {
         [Parameter("uint", "", 1)]
-        public virtual BigInteger ReturnValue1 {get; set;}
+        public virtual BigInteger ReturnValue1 { get; set; }
         [Parameter("string", "", 2)]
-        public virtual string ReturnValue2 {get; set;}
+        public virtual string ReturnValue2 { get; set; }
     }
 }

--- a/src/Nethereum.Generators.UnitTests/Expectations/Content/CSharp/ServiceGenerator.01.csharp.txt
+++ b/src/Nethereum.Generators.UnitTests/Expectations/Content/CSharp/ServiceGenerator.01.csharp.txt
@@ -12,36 +12,37 @@ using Nethereum.Contracts;
 using System.Threading;
 using CQS;
 using Functions;
+
 namespace DefaultNamespace
 {
-
     public partial class StandardContractService
     {
-    
         public static Task<TransactionReceipt> DeployContractAndWaitForReceiptAsync(Nethereum.Web3.Web3 web3, StandardContractDeployment standardContractDeployment, CancellationTokenSource cancellationTokenSource = null)
         {
             return web3.Eth.GetContractDeploymentHandler<StandardContractDeployment>().SendRequestAndWaitForReceiptAsync(standardContractDeployment, cancellationTokenSource);
         }
+
         public static Task<string> DeployContractAsync(Nethereum.Web3.Web3 web3, StandardContractDeployment standardContractDeployment)
         {
             return web3.Eth.GetContractDeploymentHandler<StandardContractDeployment>().SendRequestAsync(standardContractDeployment);
         }
+
         public static async Task<StandardContractService> DeployContractAndGetServiceAsync(Nethereum.Web3.Web3 web3, StandardContractDeployment standardContractDeployment, CancellationTokenSource cancellationTokenSource = null)
         {
             var receipt = await DeployContractAndWaitForReceiptAsync(web3, standardContractDeployment, cancellationTokenSource);
             return new StandardContractService(web3, receipt.ContractAddress);
         }
-    
+
         protected Nethereum.Web3.Web3 Web3{ get; }
-        
+
         public ContractHandler ContractHandler { get; }
-        
+
         public StandardContractService(Nethereum.Web3.Web3 web3, string contractAddress)
         {
             Web3 = web3;
             ContractHandler = web3.Eth.GetContractHandler(contractAddress);
         }
-    
+
         public Task<string> AddAdministratorRequestAsync(AddAdministratorFunction addAdministratorFunction)
         {
              return ContractHandler.SendRequestAsync(addAdministratorFunction);


### PR DESCRIPTION
This fixes the unit tests that are failing due to PR #468 after changing the output of the CSharp generated files.