### PR TITLE
Wired010/subscriptions

### DIFF
--- a/src/Nethereum.Contracts.UnitTests/Web3FunctionEncodingDecoding.cs
+++ b/src/Nethereum.Contracts.UnitTests/Web3FunctionEncodingDecoding.cs
@@ -15,7 +15,7 @@ namespace Nethereum.Contracts.UnitTests
                 @"[{""constant"":false,""inputs"":[{""name"":""a"",""type"":""uint256""}],""name"":""multiply"",""outputs"":[{""name"":""d"",""type"":""uint256""}],""type"":""function""}]";
 
 
-            var ethApi = new EthApiContractService(null, null);
+            var ethApi = new EthApiContractService(null, (RPC.TransactionManagers.TransactionManager)null);
 
 
             var contract = ethApi.GetContract(abi, "ContractAddress");
@@ -33,7 +33,7 @@ namespace Nethereum.Contracts.UnitTests
             var abi =
                 @"[{""constant"":false,""inputs"":[{""name"":""a"",""type"":""uint256""},{""name"":""b"",""type"":""string""},{""name"":""c"",""type"":""uint[3]""} ],""name"":""test"",""outputs"":[{""name"":""d"",""type"":""uint256""}],""type"":""function""}]";
 
-            var ethApi = new EthApiContractService(null, null);
+            var ethApi = new EthApiContractService(null, (RPC.TransactionManagers.TransactionManager)null);
 
             var contract = ethApi.GetContract(abi, "ContractAddress");
 

--- a/src/Nethereum.Contracts/Services/EthApiContractService.cs
+++ b/src/Nethereum.Contracts/Services/EthApiContractService.cs
@@ -14,6 +14,10 @@ namespace Nethereum.Contracts.Services
         {
         }
 
+        public EthApiContractService(IClient client, IStreamingClient streamingClient) : base(client, streamingClient)
+        {
+        }
+
         public EthApiContractService(IClient client, ITransactionManager transactionManager) : base(client,
             transactionManager)
         {

--- a/src/Nethereum.JsonRpc.Client/IBaseClient.cs
+++ b/src/Nethereum.JsonRpc.Client/IBaseClient.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace Nethereum.JsonRpc.Client
+{
+    public interface IBaseClient
+    {
+#if !DOTNET35
+        RequestInterceptor OverridingRequestInterceptor { get; set; }
+#endif
+        Task SendRequestAsync(RpcRequest request, string route = null);
+        Task SendRequestAsync(string method, string route = null, params object[] paramList);
+    }
+}

--- a/src/Nethereum.JsonRpc.Client/IClient.cs
+++ b/src/Nethereum.JsonRpc.Client/IClient.cs
@@ -2,14 +2,9 @@ using System.Threading.Tasks;
 
 namespace Nethereum.JsonRpc.Client
 {
-    public interface IClient
+    public interface IClient : IBaseClient
     {
-#if !DOTNET35
-        RequestInterceptor OverridingRequestInterceptor { get; set; }
-#endif
         Task<T> SendRequestAsync<T>(RpcRequest request, string route = null);
         Task<T> SendRequestAsync<T>(string method, string route = null, params object[] paramList);
-        Task SendRequestAsync(RpcRequest request, string route = null);
-        Task SendRequestAsync(string method, string route = null, params object[] paramList);
     }
 }

--- a/src/Nethereum.JsonRpc.Client/IStreamingClient.cs
+++ b/src/Nethereum.JsonRpc.Client/IStreamingClient.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Nethereum.JsonRpc.Client
+{
+    public interface IStreamingClient : IBaseClient
+    {
+        event EventHandler<RpcStreamingResponseMessageEventArgs> StreamingMessageReceived;
+
+        event EventHandler<RpcResponseMessageEventArgs> MessageReceived;
+    }
+}

--- a/src/Nethereum.JsonRpc.Client/IStreamingRpcRequestHandler.cs
+++ b/src/Nethereum.JsonRpc.Client/IStreamingRpcRequestHandler.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Nethereum.JsonRpc.Client
+{
+    public interface IStreamingRpcRequestHandler<TEventArgs> 
+        where TEventArgs : EventArgs
+    {
+        string MethodName { get; }
+        IStreamingClient Client { get; }
+        event EventHandler<TEventArgs> MessageRecieved;
+    }
+}

--- a/src/Nethereum.JsonRpc.Client/RpcResponseMessageEventArgs.cs
+++ b/src/Nethereum.JsonRpc.Client/RpcResponseMessageEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using Nethereum.JsonRpc.Client.RpcMessages;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nethereum.JsonRpc.Client
+{
+    public class RpcResponseMessageEventArgs : EventArgs
+    {
+        public RpcResponseMessageEventArgs(RpcResponseMessage message)
+        {
+            this.Message = message;
+        }
+
+        public RpcResponseMessage Message { get; private set; }
+    }
+}

--- a/src/Nethereum.JsonRpc.Client/RpcStreamingRequestResponseHandler.cs
+++ b/src/Nethereum.JsonRpc.Client/RpcStreamingRequestResponseHandler.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Threading.Tasks;
+using Nethereum.JsonRpc.Client.RpcMessages;
+
+namespace Nethereum.JsonRpc.Client
+{
+    public class RpcStreamingRequestResponseHandler<T> : IStreamingRpcRequestHandler<StreamingEventArgs<T>>         
+    {
+        private object id;
+        private string subscriptionId;
+
+        public RpcStreamingRequestResponseHandler(IStreamingClient client, string methodName)
+        {
+            MethodName = methodName;
+            Client = client;
+
+            Client.StreamingMessageReceived += RpcStreamingMessageResponseHandler;
+        }
+
+        public string MethodName { get; }
+
+        public IStreamingClient Client { get; }
+
+        public event EventHandler<StreamingEventArgs<T>> MessageRecieved;
+
+        protected Task SendRequestAsync(object id, params object[] paramList)
+        {
+            var request = BuildRequest(id, paramList);
+            this.id = request.Id;
+
+            return Client.SendRequestAsync(request);
+        }
+
+        public RpcRequest BuildRequest(object id, params object[] paramList)
+        {
+            if (id == null) id = Configuration.DefaultRequestId;
+            return new RpcRequest(id, MethodName, paramList);
+        }
+
+        private void RpcMessageResponseHandler(object sender, RpcResponseMessageEventArgs e)
+        {
+            if (e.Message.Id != this.id)
+            {
+                return;
+            }
+
+            // this is the ID we can use to filter future subscription messages on, if for example we were listening to block headers
+            // and new pending transactions
+            subscriptionId = e.Message.GetResult<string>();
+        }
+
+        private void RpcStreamingMessageResponseHandler(object sender, RpcStreamingResponseMessageEventArgs e)
+        {
+            if (e.Message.Params.Subscription != this.subscriptionId)
+            {
+                return;
+            }
+
+            // do something with e.Message
+            var handler = MessageRecieved;
+            if (handler != null)
+            {
+                try
+                {
+                    var args = new StreamingEventArgs<T>(e.Message.GetResult<T>());
+                    handler(this, args);
+                }
+                catch (FormatException formatException)
+                {
+                    throw new RpcResponseFormatException("Invalid format found in RPC streaming response", formatException);
+                }
+            }
+        }
+    }
+}

--- a/src/Nethereum.JsonRpc.Client/RpcStreamingResponseMessageEventArgs.cs
+++ b/src/Nethereum.JsonRpc.Client/RpcStreamingResponseMessageEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using Nethereum.JsonRpc.Client.RpcMessages;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nethereum.JsonRpc.Client
+{
+    public class RpcStreamingResponseMessageEventArgs : EventArgs
+    {
+        public RpcStreamingResponseMessageEventArgs(RpcStreamingResponseMessage message)
+        {
+            this.Message = message;
+        }
+
+        public RpcStreamingResponseMessage Message { get; private set; }
+    }
+}

--- a/src/Nethereum.JsonRpc.Client/StreamingClientBase.cs
+++ b/src/Nethereum.JsonRpc.Client/StreamingClientBase.cs
@@ -1,0 +1,92 @@
+#if !DOTNET35
+using System;
+using System.Threading.Tasks;
+using Nethereum.JsonRpc.Client.RpcMessages;
+
+namespace Nethereum.JsonRpc.Client
+{
+    public abstract class StreamingClientBase : IStreamingClient
+    {
+
+        public static TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(20.0);
+
+        public RequestInterceptor OverridingRequestInterceptor { get; set; }
+
+        public event EventHandler<RpcStreamingResponseMessageEventArgs> StreamingMessageReceived;
+
+        public event EventHandler<RpcResponseMessageEventArgs> MessageReceived;
+
+        protected virtual void OnMessageRecieved(object sender, RpcResponseMessageEventArgs args)
+        {
+            var handler = MessageReceived;
+            if (handler != null)
+            {
+                handler(this, args);
+            }
+        }
+
+        protected virtual void OnStreamingMessageRecieved(object sender, RpcStreamingResponseMessageEventArgs args)
+        {
+            var handler = StreamingMessageReceived;
+            if (handler != null)
+            {
+                handler(this, args);
+            }
+        }
+
+        protected void HandleRpcError(RpcResponseMessage response)
+        {
+            if (response.HasError)
+                throw new RpcResponseException(new RpcError(response.Error.Code, response.Error.Message,
+                    response.Error.Data));
+        }
+
+        private async Task SendInnerRequestAsync(RpcRequestMessage reqMsg,
+                                                       string route = null)
+        {
+            await SendAsync(reqMsg, route).ConfigureAwait(false);
+            //HandleRpcError(response);
+            //try
+            //{
+            //    return response.GetResult<T>();
+            //}
+            //catch (FormatException formatException)
+            //{
+            //    throw new RpcResponseFormatException("Invalid format found in RPC response", formatException);
+            //}
+        }
+
+        protected virtual async Task SendInnerRequestAsync(RpcRequest request, string route = null)
+        {
+            var reqMsg = new RpcRequestMessage(request.Id,
+                                               request.Method,
+                                               request.RawParameters);
+            await SendInnerRequestAsync(reqMsg, route).ConfigureAwait(false);
+        }
+
+        protected virtual async Task SendInnerRequestAsync(string method, string route = null,
+            params object[] paramList)
+        {
+            var request = new RpcRequestMessage(Guid.NewGuid().ToString(), method, paramList);
+            await SendInnerRequestAsync(request, route);
+        }
+
+        public virtual async Task SendRequestAsync(RpcRequest request, string route = null)
+        {
+            await SendAsync(
+                    new RpcRequestMessage(request.Id, request.Method, request.RawParameters), route)
+                .ConfigureAwait(false);
+            //HandleRpcError(response);
+        }
+
+        protected abstract Task SendAsync(RpcRequestMessage rpcRequestMessage, string route = null);
+
+        public virtual async Task SendRequestAsync(string method, string route = null, params object[] paramList)
+        {
+            var request = new RpcRequestMessage(Guid.NewGuid().ToString(), method, paramList);
+            await SendAsync(request, route).ConfigureAwait(false);
+            //HandleRpcError(response);
+        }
+    }
+}
+#endif

--- a/src/Nethereum.JsonRpc.Client/StreamingEventArgs.cs
+++ b/src/Nethereum.JsonRpc.Client/StreamingEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nethereum.JsonRpc.Client
+{
+    public class StreamingEventArgs<TEntity> : EventArgs
+    {
+        public TEntity Response { get; private set; }
+
+        public StreamingEventArgs(TEntity entity)
+        {
+            Response = entity;
+        }
+    }
+}

--- a/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Common.Logging;
+using Nethereum.JsonRpc.Client;
+using Nethereum.JsonRpc.Client.RpcMessages;
+using Newtonsoft.Json;
+
+namespace Nethereum.JsonRpc.WebSocketClient
+{
+    public class StreamingWebSocketClient : StreamingClientBase, IDisposable
+    {
+        private SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
+
+        protected readonly string Path;
+        public static int ForceCompleteReadTotalMilliseconds { get; set; } = 2000;
+
+        private Task listener;
+        private CancellationTokenSource cancellationTokenSource;
+
+        private StreamingWebSocketClient(string path, JsonSerializerSettings jsonSerializerSettings = null)
+        {
+            if (jsonSerializerSettings == null)
+                jsonSerializerSettings = DefaultJsonSerializerSettingsFactory.BuildDefaultJsonSerializerSettings();
+            this.Path = path;
+            JsonSerializerSettings = jsonSerializerSettings;
+            cancellationTokenSource = new CancellationTokenSource();            
+        }
+
+        public JsonSerializerSettings JsonSerializerSettings { get; set; }
+        private readonly object _lockingObject = new object();
+        private readonly ILog _log;
+
+        private ClientWebSocket _clientWebSocket;
+
+        public StreamingWebSocketClient(string path, JsonSerializerSettings jsonSerializerSettings = null, ILog log = null) : this(path, jsonSerializerSettings)
+        {
+            _log = log;
+        }
+
+        private async Task<ClientWebSocket> GetClientWebSocketAsync()
+        {
+            try
+            {
+                if (_clientWebSocket == null || _clientWebSocket.State != WebSocketState.Open)
+                {
+                    _clientWebSocket = new ClientWebSocket();
+                    await _clientWebSocket.ConnectAsync(new Uri(Path), new CancellationTokenSource(ConnectionTimeout).Token).ConfigureAwait(false);
+                }
+            }
+            catch (TaskCanceledException ex)
+            {
+                throw new RpcClientTimeoutException($"Rpc timeout after {ConnectionTimeout.TotalMilliseconds} milliseconds", ex);
+            }
+            catch
+            {
+                //Connection error we want to allow to retry.
+                _clientWebSocket = null;
+                throw;
+            }
+            return _clientWebSocket;
+        }
+
+        private async Task<int> ReceiveBufferedResponseAsync(ClientWebSocket client, byte[] buffer, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var timeoutToken = new CancellationTokenSource(ForceCompleteReadTotalMilliseconds).Token;
+                var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutToken);
+
+                var segmentBuffer = new ArraySegment<byte>(buffer);
+                var result = await client
+                    .ReceiveAsync(segmentBuffer, tokenSource.Token)
+                    .ConfigureAwait(false);
+                return result.Count;
+            }
+            catch (TaskCanceledException ex)
+            {
+                throw new RpcClientTimeoutException($"Rpc timeout after {ConnectionTimeout.TotalMilliseconds} milliseconds", ex);
+            }
+        }
+
+        private async Task HandleIncomingMessagesAsync(ClientWebSocket client, CancellationToken cancellationToken)
+        {
+            var lastChunk = string.Empty;
+            var readBufferSize = 512;
+
+            int bytesRead = 0;
+            byte[] chunkedBuffer = new byte[readBufferSize];
+            bytesRead = await ReceiveBufferedResponseAsync(client, chunkedBuffer, cancellationToken).ConfigureAwait(false);
+            while (!cancellationToken.IsCancellationRequested && bytesRead > 0)
+            {
+                var data = Encoding.UTF8.GetString(chunkedBuffer, 0, bytesRead);
+                var dechunkedData = DeChunkResponse(data);
+
+                foreach (var chunk in dechunkedData)
+                {
+                    var localChunk = chunk;
+                    if (!string.IsNullOrEmpty(lastChunk))
+                    {
+                        localChunk = lastChunk + localChunk;
+                    }
+
+                    try
+                    {
+                        var temp = JsonConvert.DeserializeAnonymousType(localChunk, new { id = string.Empty }, JsonSerializerSettings);
+
+                        if (temp.id == null)
+                        {
+                            // assume streaming subscription response
+                            RpcStreamingResponseMessage streamingResult = JsonConvert.DeserializeObject<RpcStreamingResponseMessage>(localChunk, JsonSerializerSettings);
+                            var streamingArgs = new RpcStreamingResponseMessageEventArgs(streamingResult);
+
+                            OnStreamingMessageRecieved(this, streamingArgs);
+                        }
+                        else
+                        {
+                            // assume regular rpc response
+                            RpcResponseMessage result = JsonConvert.DeserializeObject<RpcResponseMessage>(localChunk, JsonSerializerSettings);
+                            var rpcEventArgs = new RpcResponseMessageEventArgs(result);
+
+                            OnMessageRecieved(this, rpcEventArgs);
+
+                            continue;
+                        }
+
+                        lastChunk = string.Empty;
+                    }
+                    catch (Exception)
+                    {
+                        lastChunk = localChunk;
+                        // swallow...
+                        continue;
+                    }
+                }
+
+                bytesRead = await ReceiveBufferedResponseAsync(client, chunkedBuffer, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        protected override async Task SendAsync(RpcRequestMessage request, string route = null)
+        {
+            var logger = new RpcLogger(_log);
+            try
+            {
+                await semaphoreSlim.WaitAsync().ConfigureAwait(false);
+                var rpcRequestJson = JsonConvert.SerializeObject(request, JsonSerializerSettings);
+                var requestBytes = new ArraySegment<byte>(Encoding.UTF8.GetBytes(rpcRequestJson));
+                logger.LogRequest(rpcRequestJson);
+                var cancellationTokenSource = new CancellationTokenSource();               
+                cancellationTokenSource.CancelAfter(ConnectionTimeout);
+
+                var webSocket = await GetClientWebSocketAsync().ConfigureAwait(false);
+                await webSocket.SendAsync(requestBytes, WebSocketMessageType.Text, true, cancellationTokenSource.Token)
+                    .ConfigureAwait(false);
+
+                if (listener != null)
+                {
+                    cancellationTokenSource.Cancel();
+                    cancellationTokenSource.Dispose();
+                    cancellationTokenSource = new CancellationTokenSource();
+                }
+
+                listener = Task.Factory.StartNew(async () =>
+                {
+                    await HandleIncomingMessagesAsync(_clientWebSocket, CancellationToken.None);
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Current);
+            }
+            catch (Exception ex)
+            {
+                logger.LogException(ex);
+                throw new RpcClientUnknownException("Error occurred trying to send web socket requests(s)", ex);
+            }
+            finally
+            {
+                semaphoreSlim.Release();
+            }
+        }
+
+        public void Dispose()
+        {
+            _clientWebSocket?.Dispose();
+            cancellationTokenSource.Dispose();
+        }
+
+        private IEnumerable<string> DeChunkResponse(string response)
+        {
+            var dechunked = Regex.Replace(response, @"\}[\n\r]?\{", "}|--|{");
+            dechunked = Regex.Replace(dechunked, @"\}\][\n\r]?\[\{", "}]|--|[{");
+            dechunked = Regex.Replace(dechunked, @"\}[\n\r]?\[\{", "}|--|[{");
+            dechunked = Regex.Replace(dechunked, @"\}\][\n\r]?\{", "}]|--|{");
+            return dechunked.Split(new[] { "|--|" }, StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+}
+

--- a/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
@@ -19,7 +19,7 @@ namespace Nethereum.JsonRpc.WebSocketClient
         private SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
 
         protected readonly string Path;
-        public static int ForceCompleteReadTotalMilliseconds { get; set; } = 2000;
+        public static int ForceCompleteReadTotalMilliseconds { get; set; } = 4000;
 
         private Task listener;
         private CancellationTokenSource cancellationTokenSource;

--- a/src/Nethereum.RPC.IntegrationTests/ClientFactory.cs
+++ b/src/Nethereum.RPC.IntegrationTests/ClientFactory.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Nethereum.RPC.Tests.Testers;
+using Nethereum.JsonRpc.WebSocketClient;
 
 namespace Nethereum.RPC.Tests
 {
@@ -14,6 +15,12 @@ namespace Nethereum.RPC.Tests
         {
            var url = settings.GetRPCUrl();
            return new RpcClient(new Uri(url)); 
+        }
+
+        public static IStreamingClient GetStreamingClient(TestSettings settings)
+        {
+            var url = settings.GetLiveWSRpcUrl();
+            return new StreamingWebSocketClient(url);
         }
     }
 }

--- a/src/Nethereum.RPC.IntegrationTests/Nethereum.RPC.IntegrationTests.csproj
+++ b/src/Nethereum.RPC.IntegrationTests/Nethereum.RPC.IntegrationTests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Nethereum.ABI\Nethereum.ABI.csproj" />
+    <ProjectReference Include="..\Nethereum.JsonRpc.WebSocketClient\Nethereum.JsonRpc.WebSocketClient.csproj" />
     <ProjectReference Include="..\Nethereum.Web3\Nethereum.Web3.csproj" />
     <ProjectReference Include="..\Nethereum.RPC\Nethereum.RPC.csproj" />
     <ProjectReference Include="..\Nethereum.JsonRpc.Client\Nethereum.JsonRpc.Client.csproj" />

--- a/src/Nethereum.RPC.IntegrationTests/TestSettings.cs
+++ b/src/Nethereum.RPC.IntegrationTests/TestSettings.cs
@@ -46,6 +46,11 @@ namespace Nethereum.RPC.Tests.Testers
             return GetLiveSettingsValue("rpcUrl");
         }
 
+        public string GetLiveWSRpcUrl()
+        {
+            return GetLiveSettingsValue("wsUrl");
+        }
+
         public ulong GetBlockNumber()
         {
             return Convert.ToUInt64(GetAppSettingsValue("blockNumber"));

--- a/src/Nethereum.RPC.IntegrationTests/Testers/EthSubscriptionNewBlockHeadersTester.cs
+++ b/src/Nethereum.RPC.IntegrationTests/Testers/EthSubscriptionNewBlockHeadersTester.cs
@@ -3,22 +3,22 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethereum.JsonRpc.Client;
 using Nethereum.JsonRpc.Client.RpcMessages;
+using Nethereum.RPC.Eth.DTOs;
 using Nethereum.RPC.Eth.Subscriptions;
 using Xunit;
 
 namespace Nethereum.RPC.Tests.Testers
 {
-    public class EthPendingTransactionSubscriptionTester : StreamingRPCRequestTester
+    public class EthSubscriptionNewBlockHeadersTester : StreamingRPCRequestTester
     {
         [Fact]
-        public async Task ShouldRetrieveTransaction()
+        public async Task ShouldRetrieveBlock()
         {
             var tokenSource = new CancellationTokenSource();
-
             var recievedMessage = false;
             var successfulResponse = false;
             var failureMessage = string.Empty;
-            var successResponse = string.Empty;
+            Block successResponse = null;
             this.StreamingClient.StreamingMessageReceived += (s, e) => 
             {
                 recievedMessage = true;
@@ -29,7 +29,7 @@ namespace Nethereum.RPC.Tests.Testers
                 }
                 else
                 {
-                    successResponse = e.Message.GetResult<string>();
+                    successResponse = e.Message.GetResult<Block>();
                 }
 
                 tokenSource.Cancel();
@@ -39,21 +39,21 @@ namespace Nethereum.RPC.Tests.Testers
 
             try
             {
-                await Task.Delay(5000, tokenSource.Token);
+                await Task.Delay(10000, tokenSource.Token);
             }
             catch (TaskCanceledException)
             {
-                //swallow, escape hatch
+                // swallow, escape hatch
             }
 
             Assert.True(recievedMessage, "Did not recieved response");
             Assert.True(successfulResponse, $"Response indicated failure: {failureMessage}");
-            Assert.False(string.IsNullOrEmpty(successResponse));
+            Assert.NotNull(successResponse);
         }
 
         public override async Task ExecuteAsync(IStreamingClient client)
         {
-            var subscription = new EthNewPendingTransactionSubscription(client);
+            var subscription = new EthNewBlockHeadersSubscription(client);
             await subscription.SendRequestAsync(Guid.NewGuid());
         }
 

--- a/src/Nethereum.RPC.IntegrationTests/Testers/EthSubscriptionPendingTransactionTester.cs
+++ b/src/Nethereum.RPC.IntegrationTests/Testers/EthSubscriptionPendingTransactionTester.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethereum.JsonRpc.Client;
+using Nethereum.JsonRpc.Client.RpcMessages;
+using Nethereum.RPC.Eth.Subscriptions;
+using Xunit;
+
+namespace Nethereum.RPC.Tests.Testers
+{
+    public class EthPendingTransactionSubscriptionTester : StreamingRPCRequestTester<String[]>
+    {
+        [Fact]
+        public async Task ShouldRetrieveAccounts()
+        {
+            var recievedMessage = false;
+            var successfulResponse = false;
+            var failureMessage = string.Empty;
+            var successResponse = string.Empty;
+            this.StreamingClient.StreamingMessageReceived += (s, e) => 
+            {
+                recievedMessage = true;
+                successfulResponse = !e.Message.HasError;
+                if (e.Message.HasError)
+                {
+                    failureMessage = e.Message.Error.Message;
+                }
+                else
+                {
+                    successResponse = e.Message.GetResult<string>();
+                }
+            };
+
+            await ExecuteAsync();
+
+            await Task.Delay(5000);
+
+            Assert.True(recievedMessage, "Did not recieved response");
+            Assert.True(successfulResponse, $"Response indicated failure: {failureMessage}");
+            Assert.False(string.IsNullOrEmpty(successResponse));
+            Console.WriteLine(successResponse);
+        }
+
+        public override async Task ExecuteAsync(IStreamingClient client)
+        {
+            var subscription = new EthNewPendingTransactionSubscription(client);
+            await subscription.SendRequestAsync();
+        }
+
+        public override Type GetRequestType()
+        {
+            return typeof (EthNewPendingTransactionSubscription);
+        }
+    }
+}

--- a/src/Nethereum.RPC.IntegrationTests/Testers/IStreamingRPCRequestTester.cs
+++ b/src/Nethereum.RPC.IntegrationTests/Testers/IStreamingRPCRequestTester.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+using Nethereum.JsonRpc.Client;
+
+namespace Nethereum.RPC.Tests.Testers
+{
+    public interface IStreamingRPCRequestTester
+    {
+        Task ExecuteTestAsync(IStreamingClient client);
+        Type GetRequestType();
+    }
+}

--- a/src/Nethereum.RPC.IntegrationTests/Testers/StreamingRPCRequestTester.cs
+++ b/src/Nethereum.RPC.IntegrationTests/Testers/StreamingRPCRequestTester.cs
@@ -4,7 +4,7 @@ using Nethereum.JsonRpc.Client;
 
 namespace Nethereum.RPC.Tests.Testers
 {
-    public abstract class StreamingRPCRequestTester<T>: IStreamingRPCRequestTester
+    public abstract class StreamingRPCRequestTester: IStreamingRPCRequestTester
     {
         public IStreamingClient StreamingClient { get; set; }
 

--- a/src/Nethereum.RPC.IntegrationTests/Testers/StreamingRPCRequestTester.cs
+++ b/src/Nethereum.RPC.IntegrationTests/Testers/StreamingRPCRequestTester.cs
@@ -4,31 +4,29 @@ using Nethereum.JsonRpc.Client;
 
 namespace Nethereum.RPC.Tests.Testers
 {
-    public abstract class RPCRequestTester<T>: IRPCRequestTester
+    public abstract class StreamingRPCRequestTester<T>: IStreamingRPCRequestTester
     {
-        public IClient Client { get; set; }
         public IStreamingClient StreamingClient { get; set; }
 
         public TestSettings Settings { get; set; }
 
-        protected RPCRequestTester()
+        protected StreamingRPCRequestTester()
         {
             Settings = new TestSettings();
-            Client = ClientFactory.GetClient(Settings);
             StreamingClient = ClientFactory.GetStreamingClient(Settings);
         }
 
-        public Task<T> ExecuteAsync()
+        public Task ExecuteAsync()
         {
-            return ExecuteAsync(Client);
+            return ExecuteAsync(StreamingClient);
         }
 
-        public async Task<object> ExecuteTestAsync(IClient client)
+        public async Task ExecuteTestAsync(IStreamingClient client)
         {
-            return await ExecuteAsync(client);
+            await ExecuteAsync(client);
         }
 
-        public abstract Task<T> ExecuteAsync(IClient client);
+        public abstract Task ExecuteAsync(IStreamingClient client);
 
         public abstract Type GetRequestType();
     }

--- a/src/Nethereum.RPC.IntegrationTests/test-settings.json
+++ b/src/Nethereum.RPC.IntegrationTests/test-settings.json
@@ -1,6 +1,7 @@
 ﻿{
   "liveSettings": {
-    "rpcUrl": "https://mainnet.infura.io"
+    "rpcUrl": "https://mainnet.infura.io",
+    "wsUrl": "wss://mainnet.infura.io/ws"
   }, 
   "testSettings": {
     "defaultAccount": "0x12890d2cce102216644c59dae5baed380d84830c",

--- a/src/Nethereum.RPC/ApiMethods.cs
+++ b/src/Nethereum.RPC/ApiMethods.cs
@@ -46,6 +46,7 @@
         eth_getWork,
         eth_submitWork,
         eth_submitHashrate,
+        eth_subscribe,
         shh_post,
         shh_version,
         shh_newIdentity,

--- a/src/Nethereum.RPC/Eth/DTOs/EthNewSubscriptionInput.cs
+++ b/src/Nethereum.RPC/Eth/DTOs/EthNewSubscriptionInput.cs
@@ -1,0 +1,38 @@
+using Newtonsoft.Json;
+
+namespace Nethereum.RPC.Eth.DTOs
+{
+    /// <summary>
+    ///     Object - The transaction object
+    /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    public class NewSubscriptionInput
+    {
+        public NewSubscriptionInput()
+        {
+            FromBlock = new BlockParameter();
+        }
+
+        /// <summary>
+        ///     QUANTITY|TAG - (optional, default: "latest") Integer block number, or "latest" for the last mined block or
+        ///     "pending", "earliest" for not yet mined transactions.
+        /// </summary>
+        [JsonProperty(PropertyName = "fromBlock")]
+        public BlockParameter FromBlock { get; set; }
+
+        /// <summary>
+        ///     address: DATA|Array, 20 Bytes - (optional) Contract address or a list of addresses from which logs should
+        ///     originate.
+        /// </summary>
+        [JsonProperty(PropertyName = "address")]
+        public string[] Address { get; set; }
+
+        /// <summary>
+        ///     topics: Array of DATA, - (optional) Array of 32 Bytes DATA topics. Topics are order-dependent. Each topic can also
+        ///     be an array of DATA with "or" options.
+        /// </summary>
+        /// <see cref="https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#events" />
+        [JsonProperty(PropertyName = "topics")]
+        public object[] Topics { get; set; }
+    }
+}

--- a/src/Nethereum.RPC/Eth/Services/EthSubscriptionService.cs
+++ b/src/Nethereum.RPC/Eth/Services/EthSubscriptionService.cs
@@ -11,8 +11,11 @@ namespace Nethereum.RPC.Eth.Services
         public EthSubscriptionService(IStreamingClient client) : base(client)
         {
             NewPendingTransactionSubscription = new EthNewPendingTransactionSubscription(client);
+            NewBlockHeadersSubscription = new EthNewBlockHeadersSubscription(client);
         }
 
         public EthNewPendingTransactionSubscription NewPendingTransactionSubscription { get; private set; }
+
+        public EthNewBlockHeadersSubscription NewBlockHeadersSubscription { get; private set; }
     }
 }

--- a/src/Nethereum.RPC/Eth/Services/EthSubscriptionService.cs
+++ b/src/Nethereum.RPC/Eth/Services/EthSubscriptionService.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Nethereum.JsonRpc.Client;
+using Nethereum.RPC.Eth.Subscriptions;
+
+namespace Nethereum.RPC.Eth.Services
+{
+    public class EthSubscriptionService : RpcClientWrapper
+    {
+        public EthSubscriptionService(IStreamingClient client) : base(client)
+        {
+            NewPendingTransactionSubscription = new EthNewPendingTransactionSubscription(client);
+        }
+
+        public EthNewPendingTransactionSubscription NewPendingTransactionSubscription { get; private set; }
+    }
+}

--- a/src/Nethereum.RPC/Eth/Subscriptions/EthNewBlockHeadersSubscription.cs
+++ b/src/Nethereum.RPC/Eth/Subscriptions/EthNewBlockHeadersSubscription.cs
@@ -16,7 +16,7 @@ namespace Nethereum.RPC.Eth.Subscriptions
 
         public Task SendRequestAsync(object id)
         {
-            return base.SendRequestAsync(id, "newBlockHeaders");
+            return base.SendRequestAsync(id, "newHeads");
         }
 
         public RpcRequest BuildRequest(object id)

--- a/src/Nethereum.RPC/Eth/Subscriptions/EthNewBlockHeadersSubscription.cs
+++ b/src/Nethereum.RPC/Eth/Subscriptions/EthNewBlockHeadersSubscription.cs
@@ -1,0 +1,27 @@
+﻿using Nethereum.Hex.HexTypes;
+using Nethereum.JsonRpc.Client;
+using Nethereum.RPC.Eth.DTOs;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nethereum.RPC.Eth.Subscriptions
+{
+    public class EthNewBlockHeadersSubscription : RpcStreamingRequestResponseHandler<Block>
+    {
+        public EthNewBlockHeadersSubscription(IStreamingClient client) : base(client, ApiMethods.eth_subscribe.ToString())
+        {
+        }
+
+        public Task SendRequestAsync(object id)
+        {
+            return base.SendRequestAsync(id, "newBlockHeaders");
+        }
+
+        public RpcRequest BuildRequest(object id)
+        {
+            return base.BuildRequest(id);
+        }
+    }
+}

--- a/src/Nethereum.RPC/Eth/Subscriptions/EthNewPendingTransactionSubscription.cs
+++ b/src/Nethereum.RPC/Eth/Subscriptions/EthNewPendingTransactionSubscription.cs
@@ -1,0 +1,26 @@
+﻿using Nethereum.Hex.HexTypes;
+using Nethereum.JsonRpc.Client;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nethereum.RPC.Eth.Subscriptions
+{
+    public class EthNewPendingTransactionSubscription : RpcStreamingRequestResponseHandler<string>
+    {
+        public EthNewPendingTransactionSubscription(IStreamingClient client) : base(client, ApiMethods.eth_subscribe.ToString())
+        {
+        }
+
+        public Task SendRequestAsync(object id)
+        {
+            return base.SendRequestAsync(id, "newPendingTransactions");
+        }
+
+        public RpcRequest BuildRequest(object id)
+        {
+            return base.BuildRequest(id);
+        }
+    }
+}

--- a/src/Nethereum.RPC/Eth/Subscriptions/EthNewSyncingSubscription.cs
+++ b/src/Nethereum.RPC/Eth/Subscriptions/EthNewSyncingSubscription.cs
@@ -1,0 +1,26 @@
+﻿using Nethereum.Hex.HexTypes;
+using Nethereum.JsonRpc.Client;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nethereum.RPC.Eth.Subscriptions
+{
+    public class EthNewSyncingSubscription : RpcStreamingRequestResponseHandler<HexBigInteger>
+    {
+        public EthNewSyncingSubscription(IStreamingClient client) : base(client, ApiMethods.eth_newFilter.ToString())
+        {
+        }
+
+        public Task SendRequestAsync(object id = null)
+        {
+            return base.SendRequestAsync(id);
+        }
+
+        public RpcRequest BuildRequest(object id = null)
+        {
+            return base.BuildRequest(id);
+        }
+    }
+}

--- a/src/Nethereum.RPC/EthApiService.cs
+++ b/src/Nethereum.RPC/EthApiService.cs
@@ -17,6 +17,12 @@ namespace Nethereum.RPC
            
         }
 
+        public EthApiService(IClient client, IStreamingClient streamingClient) : this(client,
+            new TransactionManager(client))
+        {
+            Subscriptions = new EthSubscriptionService(streamingClient);
+        }
+
         public EthApiService(IClient client, ITransactionManager transactionManager) : base(client)
         {
             Client = client;
@@ -75,6 +81,8 @@ namespace Nethereum.RPC
         public EthApiBlockService Blocks { get; private set; }
 
         public EthApiFilterService Filters { get; private set; }
+
+        public EthSubscriptionService Subscriptions { get; private set; }
 
         public EthApiCompilerService Compile { get; private set; }
 #if !DOTNET35

--- a/src/Nethereum.RPC/RpcClientWrapper.cs
+++ b/src/Nethereum.RPC/RpcClientWrapper.cs
@@ -9,6 +9,13 @@ namespace Nethereum.RPC
             Client = client;
         }
 
+        public RpcClientWrapper(IStreamingClient client)
+        {
+            StreamingClient = client;
+        }
+
         public IClient Client { get; protected set; }
+
+        public IStreamingClient StreamingClient { get; protected set; }
     }
 }

--- a/src/Nethereum.Web3/Web3.cs
+++ b/src/Nethereum.Web3/Web3.cs
@@ -24,6 +24,11 @@ namespace Nethereum.Web3
             IntialiseDefaultGasAndGasPrice();
         }
 
+        public Web3(IClient client, IStreamingClient streamingClient) : this(client)
+        {
+            StreamingClient = streamingClient;
+        }
+
         public Web3(IAccount account, IClient client) : this(client)
         {
             TransactionManager = account.TransactionManager;
@@ -54,6 +59,8 @@ namespace Nethereum.Web3
         public static TransactionSigner OfflineTransactionSigner { get; } = new TransactionSigner();
 
         public IClient Client { get; private set; }
+
+        public IStreamingClient StreamingClient { get; private set; }
 
         public EthApiContractService Eth { get; private set; }
         public ShhApiService Shh { get; private set; }
@@ -95,7 +102,7 @@ namespace Nethereum.Web3
 
         protected virtual void InitialiseInnerServices()
         {
-            Eth = new EthApiContractService(Client);
+            Eth = new EthApiContractService(Client, StreamingClient);
             Shh = new ShhApiService(Client);
             Net = new NetApiService(Client);
             Personal = new PersonalApiService(Client);


### PR DESCRIPTION
Added support for pendingTransaction subscription and newBlockHeaders
subscription. Since subscriptions aren't polling based, and they use
their own RPC response format, a lot of plumbing and infrastructure code
had to be added to support the feature.

Where possible, existing code and infrastructure was refactored as
little as possible to prevent any issues with backward compatibility.

As currently implemented, streaming data is handled via events, but in
the future, C# 8 features like IAsyncEnumerable could provide an
interesting way to consume these sorts of events.

There are 2 remaining subscriptions that could be implemented: syncing
and logs. Based on the Web3JS implementation of subscriptions, these two
types will be a little unique since they have custom handlers that are
invoked.