### PR TITLE
Wired010/subscriptions

### DIFF
--- a/src/Nethereum.JsonRpc.Client/IStreamingClient.cs
+++ b/src/Nethereum.JsonRpc.Client/IStreamingClient.cs
@@ -8,5 +8,7 @@ namespace Nethereum.JsonRpc.Client
         event EventHandler<RpcStreamingResponseMessageEventArgs> StreamingMessageReceived;
 
         event EventHandler<RpcResponseMessageEventArgs> MessageReceived;
+
+        event EventHandler<RpcResponseErrorMessageEventArgs> Error;
     }
 }

--- a/src/Nethereum.JsonRpc.Client/RpcResponseErrorMessageEventArgs.cs
+++ b/src/Nethereum.JsonRpc.Client/RpcResponseErrorMessageEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nethereum.JsonRpc.Client
+{
+    public class RpcResponseErrorMessageEventArgs : EventArgs
+    {
+        public RpcResponseErrorMessageEventArgs(RpcError error)
+        {
+            this.Error = error;
+        }
+
+        public RpcError Error { get; private set; }
+    }
+}

--- a/src/Nethereum.JsonRpc.Client/StreamingClientBase.cs
+++ b/src/Nethereum.JsonRpc.Client/StreamingClientBase.cs
@@ -16,6 +16,8 @@ namespace Nethereum.JsonRpc.Client
 
         public event EventHandler<RpcResponseMessageEventArgs> MessageReceived;
 
+        public event EventHandler<RpcResponseErrorMessageEventArgs> Error;
+
         protected virtual void OnMessageRecieved(object sender, RpcResponseMessageEventArgs args)
         {
             var handler = MessageReceived;
@@ -28,6 +30,15 @@ namespace Nethereum.JsonRpc.Client
         protected virtual void OnStreamingMessageRecieved(object sender, RpcStreamingResponseMessageEventArgs args)
         {
             var handler = StreamingMessageReceived;
+            if (handler != null)
+            {
+                handler(this, args);
+            }
+        }
+
+        protected virtual void OnError(object sender, RpcResponseErrorMessageEventArgs args)
+        {
+            var handler = Error;
             if (handler != null)
             {
                 handler(this, args);

--- a/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
@@ -19,7 +19,7 @@ namespace Nethereum.JsonRpc.WebSocketClient
         private SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
 
         protected readonly string Path;
-        public static int ForceCompleteReadTotalMilliseconds { get; set; } = 4000;
+        public static int ForceCompleteReadTotalMilliseconds { get; set; } = 10000;
 
         private Task listener;
         private CancellationTokenSource cancellationTokenSource;

--- a/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
@@ -123,8 +123,17 @@ namespace Nethereum.JsonRpc.WebSocketClient
                         {
                             // assume regular rpc response
                             RpcResponseMessage result = JsonConvert.DeserializeObject<RpcResponseMessage>(localChunk, JsonSerializerSettings);
-                            var rpcEventArgs = new RpcResponseMessageEventArgs(result);
 
+                            if (result.HasError)
+                            {
+                                var error = new Client.RpcError(result.Error.Code, result.Error.Message, result.Error.Data);
+                                var rpcErrorEventArgs = new RpcResponseErrorMessageEventArgs(error);
+                                OnError(this, rpcErrorEventArgs);
+
+                                continue;
+                            }
+
+                            var rpcEventArgs = new RpcResponseMessageEventArgs(result);
                             OnMessageRecieved(this, rpcEventArgs);
 
                             continue;


### PR DESCRIPTION
Looks like I broke a bunch of the tests with my latest commit. I did run the tests locally and had most of them passing, but the DevOps pipeline wasn't as happy. I made a slight tweak to how the `SubscriptionService` is instantiated; it's now behind a `Lazy<>` that will throw an exception if no `IStreamingClient` is provided or make a new `SubscriptionService` if an `IStreamingClient` was provided. More importantly, it won't do anything until the `Subscription` property of Web3 is accessed. Hopefully that fixes the tests which broke.

I also added a new error event and increased the read timeout for `StreamingWebSocketClient` since the new block header subscription is dependent on the mining speed of the network, many times that's longer than 4 seconds.