### PR TITLE
Add subscription event handler to observable extension methods

### DIFF
--- a/src/Nethereum.RPC.Reactive/Extensions/SubscriptionEventHandlerExtensions.cs
+++ b/src/Nethereum.RPC.Reactive/Extensions/SubscriptionEventHandlerExtensions.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Nethereum.JsonRpc.Client.Streaming;
+
+namespace Nethereum.RPC.Reactive.Extensions
+{
+    public static class SubscriptionEventHandlerExtensions
+    {
+        public static IObservable<TSubscriptionDataResponse> GetDataObservable<TSubscriptionDataResponse>(
+            this RpcStreamingSubscriptionEventResponseHandler<TSubscriptionDataResponse> rpcEventHandler) =>
+            Observable
+                .Create<TSubscriptionDataResponse>(o =>
+                {
+                    var evt = Observable.FromEventPattern<StreamingEventArgs<TSubscriptionDataResponse>>(
+                        h => rpcEventHandler.SubscriptionDataResponse += h,
+                        h => rpcEventHandler.SubscriptionDataResponse -= h);
+
+                    var onSuccess = evt
+                        .Where(e => e.EventArgs.Exception == null)
+                        .Select(e => e.EventArgs.Response)
+                        .Subscribe(o);
+
+                    var onError = evt
+                        .Where(e => e.EventArgs.Exception != null)
+                        .Select(e => e.EventArgs.Exception)
+                        .Subscribe(o.OnError);
+
+                    var onCompleted = rpcEventHandler
+                        .GetUnsubscribeObservable()
+                        .Subscribe(
+                            _ => { },
+                            _ => { },
+                            o.OnCompleted);
+
+                    return new CompositeDisposable { onSuccess, onError, onCompleted };
+                })
+                .Publish()
+                .RefCount();
+
+        public static IObservable<string>
+            GetSubscribeObservable<TSubscriptionDataResponse>(this RpcStreamingSubscriptionEventResponseHandler<TSubscriptionDataResponse> rpcEventHandler) =>
+            Observable
+                .Create<string>(o =>
+                {
+                    var evt = Observable.FromEventPattern<StreamingEventArgs<string>>(
+                        h => rpcEventHandler.SubscribeResponse += h,
+                        h => rpcEventHandler.SubscribeResponse -= h);
+
+                    var onSuccess = evt
+                        .Where(e => e.EventArgs.Exception == null)
+                        .Select(e => e.EventArgs.Response)
+                        .Subscribe(o);
+
+                    var onError = evt
+                        .Where(e => e.EventArgs.Exception != null)
+                        .Select(e => e.EventArgs.Exception)
+                        .Subscribe(o.OnError);
+
+                    return new CompositeDisposable { onSuccess, onError };
+                })
+                .Take(1)
+                .Publish()
+                .RefCount();
+
+        public static IObservable<bool>
+            GetUnsubscribeObservable<TSubscriptionDataResponse>(this RpcStreamingSubscriptionEventResponseHandler<TSubscriptionDataResponse> rpcEventHandler) =>
+            Observable
+                .Create<bool>(o =>
+                {
+                    var evt = Observable.FromEventPattern<StreamingEventArgs<bool>>(
+                        h => rpcEventHandler.UnsubscribeResponse += h,
+                        h => rpcEventHandler.UnsubscribeResponse -= h);
+
+                    var onSuccess = evt
+                        .Where(e => e.EventArgs.Exception == null)
+                        .Select(e => e.EventArgs.Response)
+                        .Subscribe(o);
+
+                    var onError = evt
+                        .Where(e => e.EventArgs.Exception != null)
+                        .Select(e => e.EventArgs.Exception)
+                        .Subscribe(o.OnError);
+
+                    return new CompositeDisposable { onSuccess, onError };
+                })
+                .Take(1)
+                .Publish()
+                .RefCount();
+    }
+}

--- a/src/Nethereum.WebSocketsStreamingTest/Program.cs
+++ b/src/Nethereum.WebSocketsStreamingTest/Program.cs
@@ -1,10 +1,8 @@
 ﻿using Nethereum.Contracts;
-using Nethereum.JsonRpc.Client.RpcMessages;
 using Nethereum.JsonRpc.WebSocketStreamingClient;
 using Nethereum.RPC.Eth.DTOs;
 using System;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Threading;
 using Nethereum.Contracts.Extensions;
 using Nethereum.ABI.FunctionEncoding.Attributes;
@@ -13,6 +11,7 @@ using Nethereum.JsonRpc.Client.Streaming;
 using Nethereum.RPC.Eth.Subscriptions;
 using Nethereum.RPC.Reactive.Eth;
 using Nethereum.RPC.Reactive.Eth.Subscriptions;
+using Nethereum.RPC.Reactive.Extensions;
 
 namespace Nethereum.WebSocketsStreamingTest
 {
@@ -41,9 +40,8 @@ namespace Nethereum.WebSocketsStreamingTest
                 Console.WriteLine("New Block from event: " + e.Response.BlockHash);
             };
 
-            var disposable = Observable.FromEventPattern<StreamingEventArgs<Block>>(h => blockHeaderSubscription2.SubscriptionDataResponse += h,
-                h => blockHeaderSubscription2.SubscriptionDataResponse -= h).Subscribe(x =>
-                 Console.WriteLine("New Block from observable from event : " + x.EventArgs.Response.BlockHash)
+            blockHeaderSubscription2.GetDataObservable().Subscribe(x =>
+                 Console.WriteLine("New Block from observable from event : " + x.BlockHash)
                 );
 
             var pendingTransactionsSubscription = new EthNewPendingTransactionObservableSubscription(client);


### PR DESCRIPTION
The use of subjects is usually not recommended, unless you're dealing with both hot observables and a local source. In our case, we're dealing with an external source. Subjects are not stateless, and also implement `IDisposable`, which means all subsequent ObserverHandlers also need to be disposed. By using simple static `Observable` factory method such as `Observable.Create()` and `Observable.FromEventPattern()`, we can more easily extend the already implemented event handlers in a more reactive and functional way.