### PR TITLE
Update AccountSignerTransactionManager.cs

### DIFF
--- a/src/Nethereum.Accounts/AccountSignerTransactionManager.cs
+++ b/src/Nethereum.Accounts/AccountSignerTransactionManager.cs
@@ -63,7 +63,7 @@ namespace Nethereum.Web3.Accounts
         public string SignTransaction(TransactionInput transaction)
         {
             if (transaction == null) throw new ArgumentNullException(nameof(transaction));
-            if (!string.Equals(transaction.From.EnsureHexPrefix(), Account.Address.EnsureHexPrefix(), StringComparison.CurrentCultureIgnoreCase))
+            if (!string.Equals(transaction.From.EnsureHexPrefix(), Account.Address.EnsureHexPrefix(), StringComparison.OrdinalIgnoreCase))
                 throw new Exception("Invalid account used signing");
             SetDefaultGasPriceAndCostIfNotSet(transaction);
 


### PR DESCRIPTION
We had a lot of debugging to find this error, some addresses do not equal when casing is different and the rules of the current culture is applied. The two identical strings '0xc25aeeacaa3f110612086febfb423fb34cb9952c' and '0xc25AEEaCaA3f110612086fEbfb423fb34cB9952C' does not match in a Danish culture. As 'aa' becomes a special characters 'å' while 'aA' does not. OrdinalIgnoreCase compares the character codes without cultural aspects, and should be used for strings with hex data.