### PR TITLE
Parity- traceTransaction , result type changed from jobject to jarray

### DIFF
--- a/src/Nethereum.Parity.IntegrationTests/Tests/Trace/TraceTransactionTester.cs
+++ b/src/Nethereum.Parity.IntegrationTests/Tests/Trace/TraceTransactionTester.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Nethereum.Parity.IntegrationTests.Tests.Trace
 {
-    public class TraceTransactionTester : RPCRequestTester<JObject>
+    public class TraceTransactionTester : RPCRequestTester<JArray>
     {
         public override async Task<JObject> ExecuteAsync(IClient client)
         {

--- a/src/Nethereum.Parity/RPC/Trace/ITraceTransaction.cs
+++ b/src/Nethereum.Parity/RPC/Trace/ITraceTransaction.cs
@@ -7,6 +7,6 @@ namespace Nethereum.Parity.RPC.Trace
     public interface ITraceTransaction
     {
         RpcRequest BuildRequest(string transactionHash, object id = null);
-        Task<JObject> SendRequestAsync(string transactionHash, object id = null);
+        Task<JArray> SendRequestAsync(string transactionHash, object id = null);
     }
 }

--- a/src/Nethereum.Parity/RPC/Trace/TraceTransaction.cs
+++ b/src/Nethereum.Parity/RPC/Trace/TraceTransaction.cs
@@ -7,13 +7,13 @@ namespace Nethereum.Parity.RPC.Trace
     /// <Summary>
     ///     Returns all traces of given transaction
     /// </Summary>
-    public class TraceTransaction : RpcRequestResponseHandler<JObject>, ITraceTransaction
+    public class TraceTransaction : RpcRequestResponseHandler<JArray>, ITraceTransaction
     {
         public TraceTransaction(IClient client) : base(client, ApiMethods.trace_transaction.ToString())
         {
         }
 
-        public async Task<JObject> SendRequestAsync(string transactionHash, object id = null)
+        public async Task<JArray> SendRequestAsync(string transactionHash, object id = null)
         {
             return await base.SendRequestAsync(id, transactionHash);
         }


### PR DESCRIPTION
Parity changed the return type of TraceTransaction from json to json array , therefore i changed the return from JObject to JArray on :
TraceTransaction.cs
ITraceTransaction.cs,
Nethereum.Parity.IntegreationTests -> Trace Folder > TraceTransactionTester.cs