### PR TITLE
NewFilterInputBuilder - typed event filter building

### DIFF
--- a/src/Nethereum.ABI/net35/IntrospectionExtensions.cs
+++ b/src/Nethereum.ABI/net35/IntrospectionExtensions.cs
@@ -3,7 +3,7 @@ namespace System.Reflection
 {
 
     using System.Collections.Generic;
-    internal static class IntrospectionExtensions
+    public static class IntrospectionExtensions
     {
         // This allows us to use the new reflection API which separates Type and TypeInfo
         // while still supporting .NET 3.5 and 4.0. This class matches the API of the same

--- a/src/Nethereum.Contracts.IntegrationTests/FiltersEvents/FilterBuilderInstantiation.cs
+++ b/src/Nethereum.Contracts.IntegrationTests/FiltersEvents/FilterBuilderInstantiation.cs
@@ -1,0 +1,79 @@
+﻿using Nethereum.ABI.FunctionEncoding.Attributes;
+using Nethereum.RPC.Eth.DTOs;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+using Xunit;
+
+namespace Nethereum.Contracts.IntegrationTests.FiltersEvents
+{
+    public class FilterBuilderInstantiation
+    {
+        [Event("Transfer")]
+        public class TransferEventDTOBase : IEventDTO
+        {
+            [Parameter("address", "_from", 1, true)]
+            public string From { get; set; }
+            [Parameter("address", "_to", 2, true)]
+            public string To { get; set; }
+            [Parameter("uint256", "_value", 3, false)]
+            public BigInteger Value { get; set; }
+        }
+
+        public partial class TransferEventDTO : TransferEventDTOBase
+        {
+
+        }
+
+        [Fact]
+
+        public void GetEventFilterBuilderFromContractService()
+        {
+            var web3 = new Web3.Web3();
+
+            //via instance of IEthApiContractService 
+            NewFilterInput filterFromContract = web3.Eth.GetFilterBuilder<TransferEventDTO>()
+                .AddTopic(t => t.From, "")
+                .AddTopic(t => t.To, "")
+                .Build(contractAddresses: new string[] { "", "" });
+
+            Assert.NotNull(filterFromContract);
+
+        }
+
+        [Fact]
+
+        public void GetEventFilterBuilderFromEvent()
+        {
+            var web3 = new Web3.Web3();
+
+            var transferEvent = web3.Eth.GetEvent<TransferEventDTO>();
+
+            //from instance of an Event
+            NewFilterInput filterFromEvent = transferEvent.GetFilterBuilder()
+                .AddTopic(t => t.From, "")
+                .AddTopic(t => t.To, "")
+                .Build(contractAddresses: new string[] { "", "" });
+
+            Assert.NotNull(filterFromEvent);
+
+        }
+
+        [Fact]
+
+        public void GetEventFilterBuilderFromEventDto()
+        {
+            var transferEventDto = new TransferEventDTO();
+
+            //from instance of an Event
+            NewFilterInput filterFromEventDto = transferEventDto.GetFilterBuilder()
+                .AddTopic(t => t.From, "")
+                .AddTopic(t => t.To, "")
+                .Build(contractAddresses: new string[] { "", "" });
+
+            Assert.NotNull(filterFromEventDto);
+
+        }
+    }
+}

--- a/src/Nethereum.Contracts.UnitTests/FilterInputBuilderTests.cs
+++ b/src/Nethereum.Contracts.UnitTests/FilterInputBuilderTests.cs
@@ -1,0 +1,289 @@
+﻿using Nethereum.ABI.FunctionEncoding.Attributes;
+using Nethereum.Contracts;
+using Nethereum.Hex.HexConvertors.Extensions;
+using System;
+using System.Linq;
+using System.Numerics;
+using Xunit;
+
+namespace Nethereum.Contracts.UnitTests
+{
+    public class FilterInputBuilderTests
+    {
+        [Event("Transfer")]
+        public class TransferEvent
+        {
+            [Parameter("address", "_from", 1, true)]
+            public string From { get; set; }
+
+            [Parameter("address", "_to", 2, true)] 
+            public string To { get; set; }
+
+            [Parameter("uint256", "_value", 3, true)]
+            public BigInteger Value { get; set; }
+            
+            [Parameter("uint256", "_notIndexed", 3, false)]
+            public uint NotIndexed { get; set; }
+
+            public uint NotAnEventParameter { get; set; }
+        }
+
+        [Event("Transfer")]
+        public class TransferEvent_ERC20
+        {
+            [Parameter("address", "_from", 1, true)]
+            public string From { get; set; }
+
+            [Parameter("address", "_to", 2, true)] 
+            public string To { get; set; }
+
+            [Parameter("uint256", "_value", 3, false)]
+            public BigInteger Value { get; set; }
+            
+        }
+
+        [Event("TransferEvent_WithEmptyParameterNames")]
+        public class TransferEvent_WithEmptyParameterNames
+        {
+            [Parameter("address", "", 1, true)]
+            public string From { get; set; }
+
+            [Parameter("address", null, 2, true)] 
+            public string To { get; set; }
+
+            [Parameter("uint256", " ", 3, true)]
+            public BigInteger Value { get; set; }
+        }
+
+        [Fact]
+        public void Topic_Value_Array_Length_Always_Equals_Signature_Plus_Count_Of_Indexed_Parameters()
+        {
+            var filter = new FilterInputBuilder<TransferEvent_ERC20>().Build();
+            Assert.Equal(3, filter.Topics.Length);
+
+            var filterFrom = new FilterInputBuilder<TransferEvent_ERC20>()
+                .AddTopic(tfr => tfr.From, "0xdfa70b70b41d77a7cdd8b878f57521d47c064d8c")
+                .Build();
+
+            Assert.Equal(3, filterFrom.Topics.Length);
+
+            var filterTo = new FilterInputBuilder<TransferEvent_ERC20>()
+                .AddTopic(tfr => tfr.To, "0xefa70b70b41d77a7cdd8b878f57521d47c064d8c")
+                .Build();
+
+            Assert.Equal(3, filterTo.Topics.Length);
+
+            var filterFromAndTo = new FilterInputBuilder<TransferEvent_ERC20>()
+                .AddTopic(tfr => tfr.From, "0xdfa70b70b41d77a7cdd8b878f57521d47c064d8c")
+                .AddTopic(tfr => tfr.To, "0xefa70b70b41d77a7cdd8b878f57521d47c064d8c")
+                .Build();
+
+            Assert.Equal(3, filterFromAndTo.Topics.Length);
+
+
+        }
+
+        [Fact]
+        public void Assigns_Event_Signature_To_Topic0()
+        {
+            var filter = new FilterInputBuilder<TransferEvent>().Build();
+
+            var eventAbi = ABITypedRegistry.GetEvent<TransferEvent>();
+
+            Assert.Equal(eventAbi.Sha3Signature.EnsureHexPrefix(), filter.Topics.FirstOrDefault());
+
+            Assert.False(filter.IsTopicFiltered(1));
+            Assert.False(filter.IsTopicFiltered(2));
+            Assert.False(filter.IsTopicFiltered(3));
+        }
+
+        [Fact]
+        public void Can_Assign_To_Topic1()
+        {
+            var from = "0xc14934679e71ef4d18b6ae927fe2b953c7fd9b91";
+
+            var filter = new FilterInputBuilder<TransferEvent>()
+                .AddTopic((t) => t.From, from)
+                .Build();
+
+            Assert.Equal("0x000000000000000000000000c14934679e71ef4d18b6ae927fe2b953c7fd9b91", 
+                filter.GetFirstTopicValueAsString(1));
+
+            Assert.False(filter.IsTopicFiltered(2));
+            Assert.False(filter.IsTopicFiltered(3));
+        }
+
+        [Fact]
+        public void Can_Assign_Many_Values_To_A_Topic()
+        {
+            var address1 = "0xc14934679e71ef4d18b6ae927fe2b953c7fd9b91";
+            var address2 = "0xc24934679e71ef4d18b6ae927fe2b953c7fd9b91";
+
+            var filter = new FilterInputBuilder<TransferEvent>()
+                .AddTopic((t) => t.From, address1)
+                .AddTopic((t) => t.From, address2)
+                .Build();
+
+            var topicValues = filter.GetTopicValues(1);
+
+            Assert.Equal("0x000000000000000000000000c14934679e71ef4d18b6ae927fe2b953c7fd9b91", 
+                topicValues[0].ToString());
+
+            Assert.Equal("0x000000000000000000000000c24934679e71ef4d18b6ae927fe2b953c7fd9b91", 
+                topicValues[1].ToString());
+        }
+
+        [Fact]
+        public void Can_Assign_Many_Values_To_A_Topic_At_Once()
+        {
+            var address1 = "0xc14934679e71ef4d18b6ae927fe2b953c7fd9b91";
+            var address2 = "0xc24934679e71ef4d18b6ae927fe2b953c7fd9b91";
+
+            var filter = new FilterInputBuilder<TransferEvent>()
+                .AddTopic((t) => t.From, new []{address1, address2})
+                .Build();
+
+            var topicValues = filter.GetTopicValues(1);
+
+            Assert.Equal("0x000000000000000000000000c14934679e71ef4d18b6ae927fe2b953c7fd9b91", 
+                topicValues[0].ToString());
+
+            Assert.Equal("0x000000000000000000000000c24934679e71ef4d18b6ae927fe2b953c7fd9b91", 
+                topicValues[1].ToString());
+        }
+
+        [Fact]
+        public void Can_Assign_To_Topic2()
+        {
+            var to = "0xc14934679e71ef4d18b6ae927fe2b953c7fd9b91";
+
+            var filter = new FilterInputBuilder<TransferEvent>()
+                .AddTopic(template => template.To, to)
+                .Build();
+
+            Assert.False(filter.IsTopicFiltered(1));
+            Assert.Equal("0x000000000000000000000000c14934679e71ef4d18b6ae927fe2b953c7fd9b91", 
+                filter.GetFirstTopicValueAsString(2));
+            Assert.False(filter.IsTopicFiltered(3));
+        }
+
+        [Fact]
+        public void Can_Assign_To_Topic3()
+        {
+            var value = BigInteger.One;
+
+            var filter = new FilterInputBuilder<TransferEvent>()
+                .AddTopic(template => template.Value, value)
+                .Build();
+
+            Assert.False(filter.IsTopicFiltered(1));
+            Assert.False(filter.IsTopicFiltered(2));
+            Assert.Equal("0x0000000000000000000000000000000000000000000000000000000000000001", 
+                filter.GetFirstTopicValueAsString(3));
+        }
+
+
+        [Fact]
+        public void Can_Assign_To_Multiple_Topics()
+        {
+            var from = "0xc14934679e71ef4d18b6ae927fe2b953c7fd9b91";
+            var to = "0xc14934679e71ef4d18b6ae927fe2b953c7fd9b92";
+            var value = BigInteger.One;
+
+            var filter = new FilterInputBuilder<TransferEvent>()
+                .AddTopic(template => template.From, from)
+                .AddTopic(template => template.To,  to)
+                .AddTopic(template => template.Value, value)
+                .Build();
+
+            Assert.Equal("0x000000000000000000000000c14934679e71ef4d18b6ae927fe2b953c7fd9b91", 
+                filter.GetFirstTopicValueAsString(1));
+
+            Assert.Equal("0x000000000000000000000000c14934679e71ef4d18b6ae927fe2b953c7fd9b92", 
+                filter.GetFirstTopicValueAsString(2));
+
+            Assert.Equal("0x0000000000000000000000000000000000000000000000000000000000000001", 
+                filter.GetFirstTopicValueAsString(3));
+        }
+
+        [Fact]
+        public void When_Parameter_Name_Is_Empty_Uses_Order_To_Find_Topic()
+        {
+            var from = "0xc14934679e71ef4d18b6ae927fe2b953c7fd9b91";
+            var to = "0xc14934679e71ef4d18b6ae927fe2b953c7fd9b92";
+            var value = BigInteger.One;
+
+            var filter = new FilterInputBuilder<TransferEvent_WithEmptyParameterNames>()
+                .AddTopic(template => template.From, from)
+                .AddTopic(template => template.To,  to)
+                .AddTopic(template => template.Value, value)
+                .Build();
+
+            Assert.Equal("0x000000000000000000000000c14934679e71ef4d18b6ae927fe2b953c7fd9b91", 
+                filter.GetFirstTopicValueAsString(1));
+
+            Assert.Equal("0x000000000000000000000000c14934679e71ef4d18b6ae927fe2b953c7fd9b92", 
+                filter.GetFirstTopicValueAsString(2));
+
+            Assert.Equal("0x0000000000000000000000000000000000000000000000000000000000000001", 
+                filter.GetFirstTopicValueAsString(3));
+        }
+
+        [Fact]
+        public void Assigns_Specified_Contract_Addresses()
+        {
+            var ContractAddresses = new []
+            {
+                "0xC03cDD393C89D169bd4877d58f0554f320f21037",
+                "0xD03cDD393C89D169bd4877d58f0554f320f21037"
+            };
+
+            var filter = new FilterInputBuilder<TransferEvent>().Build(ContractAddresses);
+
+            Assert.True(filter.Address.SequenceEqual(ContractAddresses));
+        }
+
+        [Fact]
+        public void Assigns_Specified_Contract_Address()
+        {
+            var contractAddress = 
+                "0xC03cDD393C89D169bd4877d58f0554f320f21037";
+
+            var filter = new FilterInputBuilder<TransferEvent>().Build(contractAddress);
+
+            Assert.Single(filter.Address, contractAddress);
+        }
+
+        [Fact]
+        public void Assigns_Specified_Block_Numbers()
+        {
+            var range = new BlockRange(15, 25);
+
+            var filter = new FilterInputBuilder<TransferEvent>().Build(blockRange: range);
+
+            Assert.Equal(range.From, filter.FromBlock.BlockNumber.Value);
+            Assert.Equal(range.To, filter.ToBlock.BlockNumber.Value);
+        }
+
+        [Fact]
+        public void When_Assigning_To_A_Non_Indexed_Property_It_Will_Throw_Argument_Exception()
+        {
+            var x = Assert.Throws<ArgumentException>(() => 
+                new FilterInputBuilder<TransferEvent>()
+                    .AddTopic((t) => t.NotIndexed, (uint)1));
+
+            Assert.Equal("Property 'NotIndexed' does not represent a topic. The property must have a ParameterAttribute which is flagged as indexed", x.Message);
+        }
+
+        [Fact]
+        public void When_Assigning_To_A_Property_Without_A_Parameter_Attribute_It_Will_Throw_Argument_Exception()
+        {
+            var x = Assert.Throws<ArgumentException>(() => 
+                new FilterInputBuilder<TransferEvent>()
+                    .AddTopic((t) => t.NotAnEventParameter, (uint)1));
+
+            Assert.Equal("Property 'NotAnEventParameter' does not represent a topic. The property must have a ParameterAttribute which is flagged as indexed", x.Message);
+                
+        }
+    }
+}

--- a/src/Nethereum.Contracts/Builders/FilterInput/BlockRange.cs
+++ b/src/Nethereum.Contracts/Builders/FilterInput/BlockRange.cs
@@ -1,0 +1,55 @@
+﻿using Nethereum.Hex.HexTypes;
+using System;
+using System.Numerics;
+
+namespace Nethereum.Contracts
+{
+    public struct BlockRange: 
+        IEquatable<BlockRange>
+    {
+        private readonly int _hashCode;
+
+        public BlockRange(ulong from, ulong to):
+            this(new BigInteger(from), new BigInteger(to))
+        {
+        }
+
+        public BlockRange(BigInteger from, BigInteger to):
+            this(new HexBigInteger(from), new HexBigInteger(to))
+        {
+        }
+
+        public BlockRange(HexBigInteger from, HexBigInteger to)
+        {
+            From = from;
+            To = to;
+            BlockCount = (To.Value - From.Value) + 1;
+            _hashCode = new { From, To }.GetHashCode();
+        }
+
+
+        public HexBigInteger From { get;  }
+        public HexBigInteger To { get; }
+        public BigInteger BlockCount { get; }
+
+        public bool Equals(BlockRange other)
+        {
+            return From.Equals(other.From.Value) && To.Equals(other.To.Value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is BlockRange other)
+            {
+                return Equals(other);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return _hashCode;
+        }
+    }
+}

--- a/src/Nethereum.Contracts/Builders/FilterInput/FilterExtensions.cs
+++ b/src/Nethereum.Contracts/Builders/FilterInput/FilterExtensions.cs
@@ -1,0 +1,74 @@
+﻿using Nethereum.RPC.Eth.DTOs;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nethereum.Contracts
+{
+    public static class FilterExtensions
+    {
+        private readonly static object[] EmptyObjectArray = new object[0];
+        public static string Key(this FilterLog log)
+        {
+            if (log.TransactionHash == null || log.LogIndex == null)
+                return log.GetHashCode().ToString();
+
+            return $"{log.TransactionHash}{log.LogIndex.HexValue}";
+        }
+
+        public static Dictionary<string, FilterLog> Merge(this Dictionary<string, FilterLog> masterList, FilterLog[] candidates)
+        {
+            foreach (var log in candidates)
+            {
+                var key = log.Key();
+
+                if (!masterList.ContainsKey(key))
+                {
+                    masterList.Add(key, log);
+                }
+            }
+
+            return masterList;
+        }
+
+        public static void SetBlockRange(this NewFilterInput filter, BlockRange range)
+        {
+            filter.FromBlock = new BlockParameter(range.From);
+            filter.ToBlock = new BlockParameter(range.To);
+        }
+
+        public static bool IsTopicFiltered(this NewFilterInput filter, uint topicNumber)
+        {
+            var filterValue = filter.GetFirstTopicValue(topicNumber);
+            return filterValue != null;
+        }
+
+        public static string GetFirstTopicValueAsString(this NewFilterInput filter, uint topicNumber)
+        {
+            var filterValue = filter.GetFirstTopicValue(topicNumber);
+            return filterValue?.ToString();
+        }
+
+        public static object GetFirstTopicValue(this NewFilterInput filter, uint topicNumber)
+        {
+            var topicValues = filter.GetTopicValues(topicNumber);
+            return topicValues.FirstOrDefault();
+        }
+
+        public static object[] GetTopicValues(this NewFilterInput filter, uint topicNumber)
+        {
+            var allTopics = filter.Topics;
+
+            if (allTopics == null) return EmptyObjectArray;
+            if (allTopics.Length < 2) return EmptyObjectArray;
+            if (topicNumber > allTopics.Length) return EmptyObjectArray;
+
+            if (allTopics[topicNumber] is object[] topicValues)
+                return topicValues;
+
+            if (allTopics[topicNumber] is object val)
+                return new [] {val};
+
+            return EmptyObjectArray;
+        }
+    }
+}

--- a/src/Nethereum.Contracts/Builders/FilterInput/FilterInputBuilder_T.cs
+++ b/src/Nethereum.Contracts/Builders/FilterInput/FilterInputBuilder_T.cs
@@ -1,0 +1,115 @@
+﻿using Nethereum.ABI.Model;
+using Nethereum.RPC.Eth.DTOs;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Nethereum.Contracts
+{
+    /// <summary>
+    /// Builds a filter based on indexed parameters on an event DTO query template.
+    /// The DTO should have properties decorated with ParameterAttribute
+    /// Only ParameterAttributes flagged as indexed are included
+    /// Use SetTopic to set a value on a indexed property on the query template
+    /// Values set on the query template are put in to the filter when Build is called
+    /// </summary>
+    /// <typeparam name="TEventDTo"></typeparam>
+    public class FilterInputBuilder<TEventDTo> where TEventDTo : class
+    {
+        private readonly EventABI _eventAbi;
+        private readonly TopicFilterContainer<TEventDTo> _topics;
+
+        public FilterInputBuilder()
+        {
+            _eventAbi = ABITypedRegistry.GetEvent<TEventDTo>();
+            _topics = new TopicFilterContainer<TEventDTo>();
+        }
+
+        public FilterInputBuilder<TEventDTo> AddTopic<TPropertyType>(
+            Expression<Func<TEventDTo, TPropertyType>> propertySelector, IEnumerable<TPropertyType> desiredValues)
+        {
+            foreach (var desiredValue in desiredValues)
+            {
+                AddTopic(propertySelector, desiredValue);
+            }
+
+            return this;
+        }
+
+        public FilterInputBuilder<TEventDTo> AddTopic<TPropertyType>(
+            Expression<Func<TEventDTo, TPropertyType>> propertySelector, TPropertyType desiredValue)
+        {
+            var member = propertySelector.Body as MemberExpression; 
+            var propertyInfo = member?.Member as PropertyInfo;
+
+            _topics
+                .GetTopic(propertyInfo)
+                .AddValue(desiredValue);
+
+            return this;
+        }
+
+        public NewFilterInput Build(string contractAddress, BlockRange? blockRange = null)
+        {
+            return Build(new[] {contractAddress}, blockRange);
+        }
+
+        public NewFilterInput Build(string contractAddress, BlockParameter from, BlockParameter to)
+        {
+            return Build(new[] { contractAddress }, from, to);
+        }
+
+
+        public NewFilterInput Build(string[] contractAddresses = null, BlockRange? blockRange = null)
+        {
+            BlockParameter from = blockRange == null ? null : new BlockParameter(blockRange.Value.From);
+            BlockParameter to = blockRange == null ? null : new BlockParameter(blockRange.Value.To);
+
+            return Build(contractAddresses, from, to);
+
+        }
+
+        public NewFilterInput Build(string[] contractAddresses, BlockParameter from, BlockParameter to)
+        {
+            if (_topics.Empty)
+            {
+                return _eventAbi.CreateFilterInput(contractAddresses, from, to);
+            }
+
+            //if the object array exceeds the length of the topics on the abi
+            //the filter no longer works
+
+            //one indexed topic
+            if (_topics.Topic2 == TopicFilter.Empty)
+            {
+                return _eventAbi.CreateFilterInput(
+                    contractAddresses,
+                    _topics.Topic1.GetValues(),
+                    from,
+                    to);
+            }
+
+            //two indexed topics
+            if (_topics.Topic3 == TopicFilter.Empty)
+            {
+                return _eventAbi.CreateFilterInput(
+                    contractAddresses,
+                    _topics.Topic1.GetValues(),
+                    _topics.Topic2.GetValues(),
+                    from,
+                    to);
+            }
+
+            //three indexed topics
+            return _eventAbi.CreateFilterInput(
+                contractAddresses,
+                _topics.Topic1.GetValues(),
+                _topics.Topic2.GetValues(),
+                _topics.Topic3.GetValues(),
+                from,
+                to);
+        }
+
+    }
+}

--- a/src/Nethereum.Contracts/Builders/FilterInput/TopicFilter.cs
+++ b/src/Nethereum.Contracts/Builders/FilterInput/TopicFilter.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Nethereum.ABI.FunctionEncoding.Attributes;
+
+namespace Nethereum.Contracts
+{
+    internal class TopicFilter
+    {
+        internal static readonly TopicFilter Empty = new TopicFilter(null, null);
+
+        private List<object> _values;
+
+        internal TopicFilter(PropertyInfo eventDtoProperty, ParameterAttribute parameterAttribute)
+        {
+            EventDtoProperty = eventDtoProperty;
+            ParameterAttribute = parameterAttribute;
+        }
+
+        public PropertyInfo EventDtoProperty { get; }
+        public ParameterAttribute ParameterAttribute { get; }
+
+        public object[] GetValues()
+        {
+            return _values == null || _values.Count == 0 ? null : _values.ToArray();
+        }
+
+        public void AddValue(object val)
+        {
+            if (_values == null)
+            {
+                _values = new List<object>();
+            }
+            _values.Add(val);
+        }
+    }
+}

--- a/src/Nethereum.Contracts/Builders/FilterInput/TopicFilterContainer.cs
+++ b/src/Nethereum.Contracts/Builders/FilterInput/TopicFilterContainer.cs
@@ -1,0 +1,44 @@
+﻿using Nethereum.ABI.FunctionEncoding.Attributes;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Nethereum.Contracts
+{
+    internal class TopicFilterContainer<T> where T: class
+    {
+        internal TopicFilterContainer()
+        {
+            var indexedParameters = PropertiesExtractor
+                .GetPropertiesWithParameterAttribute(typeof(T))
+                .Select(p => new TopicFilter(p, p.GetCustomAttribute<ParameterAttribute>(true)))
+                .Where(p => p.ParameterAttribute?.Parameter.Indexed ?? false)
+                .OrderBy(p => p.ParameterAttribute.Order)
+                .ToArray();
+
+            Empty = indexedParameters.Length == 0;
+
+            Topic1 = indexedParameters.Length > 0 ? indexedParameters[0] : TopicFilter.Empty;
+            Topic2 = indexedParameters.Length > 1 ? indexedParameters[1] : TopicFilter.Empty;
+            Topic3 = indexedParameters.Length > 2 ? indexedParameters[2] : TopicFilter.Empty;
+
+            Topics = new []{Topic1, Topic2, Topic3};
+        }
+
+        public bool Empty { get; private set; }
+
+        public TopicFilter Topic1 { get; private set; }
+        public TopicFilter Topic2 { get; private set; }
+        public TopicFilter Topic3 { get; private set; }
+
+        private TopicFilter[] Topics { get; set; }
+
+        public TopicFilter GetTopic(PropertyInfo pInfo)
+        {
+            return Topics
+                       .FirstOrDefault(t => t.EventDtoProperty.Name == pInfo.Name) ?? 
+                   throw new ArgumentException($"Property '{pInfo.Name}' does not represent a topic. The property must have a ParameterAttribute which is flagged as indexed");;
+        }
+        
+    }
+}

--- a/src/Nethereum.Contracts/Extensions/EventExtensions.cs
+++ b/src/Nethereum.Contracts/Extensions/EventExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Nethereum.ABI.FunctionEncoding;
 using Nethereum.ABI.FunctionEncoding.Attributes;
 using Nethereum.ABI.Model;
+using Nethereum.Contracts.Services;
 using Nethereum.Hex.HexConvertors.Extensions;
 using Nethereum.RPC.Eth.DTOs;
 using Nethereum.Util;
@@ -68,6 +69,21 @@ namespace Nethereum.Contracts
         {
             var eventABI = ABITypedRegistry.GetEvent<TEventDTO>();
             return eventABI;
+        }
+
+        public static FilterInputBuilder<TEventDTO> GetFilterBuilder<TEventDTO>(this IEthApiContractService contractService) where TEventDTO : class, IEventDTO, new()
+        {
+            return new FilterInputBuilder<TEventDTO>();
+        }
+
+        public static FilterInputBuilder<TEventDTO> GetFilterBuilder<TEventDTO>(this Event<TEventDTO> e) where TEventDTO : class,  IEventDTO, new()
+        {
+            return new FilterInputBuilder<TEventDTO>();
+        }
+
+        public static FilterInputBuilder<TEventDTO> GetFilterBuilder<TEventDTO>(this TEventDTO eventDTO) where TEventDTO : class, IEventDTO
+        {
+            return new FilterInputBuilder<TEventDTO>();
         }
 
         public static EventTopicBuilder GetTopicBuilder(this EventABI eventABI)


### PR DESCRIPTION
Typed filter building implementation e.g.

```
            var web3 = new Web3.Web3();

            NewFilterInput filterFromContract = web3.Eth.GetFilterBuilder<TransferEventDTO>()
                .AddTopic(t => t.From, "<from>")
                .AddTopic(t => t.To, "<to>")
                .Build(contractAddresses: new string[] { "address1", "address2" });
```

Classes created originally in BlockchainProcessing project.
Some extension methods for easy builder instantiation from common starting points

NOTE: TopicFilter and TopicFilterContainer are marked as internal to avoid usage outside of the assembly.  They are pretty specific to the NewFilterInputBuilder and would likely cause confusion if used elsewhere.

Implementation put in specific sub folder for now for isolation.  It's likely further merging and replacing of existing code is required.  

IntrospectionExtensions made public to allow usage in Nethereum.Contracts