### PR TITLE
ABI Deserialisation from JArray

### DIFF
--- a/src/Nethereum.ABI.UnitTests/AbiDeserialiseTuplesTests.cs
+++ b/src/Nethereum.ABI.UnitTests/AbiDeserialiseTuplesTests.cs
@@ -1,4 +1,5 @@
 ﻿using Nethereum.ABI.JsonDeserialisation;
+using Newtonsoft.Json.Linq;
 using System.Linq;
 using Xunit;
 
@@ -25,5 +26,13 @@ namespace Nethereum.ABI.UnitTests
             Assert.Equal("0cc400bd", functionABI.Sha3Signature);
         }
 
+        [Fact]
+        public void ShouldDeserialiseJArrayStyleABI() {
+            var abi = "[{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"components\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"name\":\"productId\",\"type\":\"uint256\"},{\"name\":\"quantity\",\"type\":\"uint256\"}],\"name\":\"lineItem\",\"type\":\"tuple[]\"},{\"name\":\"customerId\",\"type\":\"uint256\"}],\"name\":\"purchaseOrder\",\"type\":\"tuple\"}],\"name\":\"SetPurchaseOrder\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"GetPurchaseOrder2\",\"outputs\":[{\"components\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"components\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"name\":\"productId\",\"type\":\"uint256\"},{\"name\":\"quantity\",\"type\":\"uint256\"}],\"name\":\"lineItem\",\"type\":\"tuple[]\"},{\"name\":\"customerId\",\"type\":\"uint256\"}],\"name\":\"purchaseOrder\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"GetPurchaseOrder\",\"outputs\":[{\"components\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"components\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"name\":\"productId\",\"type\":\"uint256\"},{\"name\":\"quantity\",\"type\":\"uint256\"}],\"name\":\"lineItem\",\"type\":\"tuple[]\"},{\"name\":\"customerId\",\"type\":\"uint256\"}],\"name\":\"purchaseOrder\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"sender\",\"type\":\"address\"},{\"components\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"components\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"name\":\"productId\",\"type\":\"uint256\"},{\"name\":\"quantity\",\"type\":\"uint256\"}],\"name\":\"lineItem\",\"type\":\"tuple[]\"},{\"name\":\"customerId\",\"type\":\"uint256\"}],\"indexed\":false,\"name\":\"purchaseOrder\",\"type\":\"tuple\"}],\"name\":\"PurchaseOrderChanged\",\"type\":\"event\"}]";
+            var contractAbi = new ABIDeserialiser().DeserialiseContract(JArray.Parse(abi));
+            var functionABI = contractAbi.Functions.FirstOrDefault(e => e.Name == "SetPurchaseOrder");
+            var sig = functionABI.Sha3Signature;
+            Assert.Equal("0cc400bd", functionABI.Sha3Signature);
+        }
     }
 }

--- a/src/Nethereum.ABI/JsonDeserialisation/ABIDeserialiser.cs
+++ b/src/Nethereum.ABI/JsonDeserialisation/ABIDeserialiser.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
-//using System.Dynamic;
 using Nethereum.ABI.Model;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Nethereum.ABI.JsonDeserialisation
 {
@@ -92,10 +92,19 @@ namespace Nethereum.ABI.JsonDeserialisation
             return parameters.ToArray();
         }
 
-        public ContractABI DeserialiseContract(string abi)
+        public ContractABI DeserialiseContract(string abi) 
         {
             var convertor = new ExpandoObjectConverter();
-            var contract = JsonConvert.DeserializeObject<List<Dictionary<string,object>>>(abi, convertor);
+            var contract = JsonConvert.DeserializeObject<List<IDictionary<string, object>>>(abi, convertor);
+            return DeserialiseContractBody(contract);
+        }
+        public ContractABI DeserialiseContract(JArray abi) {
+            var convertor = new JObjectToExpandoConverter();
+            return DeserialiseContractBody(convertor.JObjectArray(abi));
+        }
+
+        private ContractABI DeserialiseContractBody(List<IDictionary<string, object>> contract)
+        {
             var functions = new List<FunctionABI>();
             var events = new List<EventABI>();
             ConstructorABI constructor = null;

--- a/src/Nethereum.ABI/JsonDeserialisation/ExpandoConvertor.cs
+++ b/src/Nethereum.ABI/JsonDeserialisation/ExpandoConvertor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 //using System.Dynamic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Nethereum.ABI.JsonDeserialisation
 {
@@ -30,7 +31,7 @@ namespace Nethereum.ABI.JsonDeserialisation
         /// </returns>
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(Dictionary<string, object>);
+            return objectType == typeof(IDictionary<string, object>);
         }
 
         /// <summary>
@@ -141,6 +142,44 @@ namespace Nethereum.ABI.JsonDeserialisation
 
                     throw new Exception("Unexpected token when converting ExpandoObject");
             }
+        }
+    }
+
+    // Converting ABI as JArray, JObject into ExpandoObject style
+    // This is only available for ABI, not generic JObject/ExpandoObject conversion
+    public class JObjectToExpandoConverter {
+        public List<IDictionary<string, object>> JObjectArray(JArray array) {
+            var l = new List<IDictionary<string, object>>();
+            foreach(JObject obj in array)
+                l.Add(JObject(obj));
+            return l;
+        }
+        public List<object> JArray(JArray array) {
+            var l = new List<object>();
+            foreach(JToken token in array)
+                l.Add(JToken(token));
+            return l;
+        }
+        public IDictionary<string, object> JObject(JObject obj) {
+            var dic = new Dictionary<string, object>();
+            foreach(var pair in obj) {
+                dic[pair.Key] = JToken(pair.Value);
+            }
+            return dic;
+        }
+        public object JToken(JToken token) {
+            if(token is JObject)
+                return JObject((JObject)token);
+            else if(token is JArray)
+                return JArray((JArray)token);
+            else if(token.Type == JTokenType.String)
+                return token.Value<string>();
+            else if(token.Type == JTokenType.Boolean)
+                return token.Value<bool>();
+            else if(token.Type == JTokenType.Integer)
+                return token.Value<int>();
+            else
+                throw new Exception("unexpected token type " + token.Type);
         }
     }
 }


### PR DESCRIPTION
This commit enables ABI deserialisation from parsed JArray. Currently ABIDeserializer can accept only string style ABI.
I think that it is convenient in the following cases.

 * sharing same ABI within multiple Contract objects.
 * obtaining ABI from large json object such as the result of solidity compiler.

If we do not consider .NET3.5, I can support List<ExpandoObject> version of ABI desieialisation.