### PR TITLE
HexBigInteger ToString 

### DIFF
--- a/src/Nethereum.Hex/HexTypes/HexBigInteger.cs
+++ b/src/Nethereum.Hex/HexTypes/HexBigInteger.cs
@@ -24,5 +24,10 @@ namespace Nethereum.Hex.HexTypes
 
             return false;
         }
+
+        public override string ToString()
+        {
+            return value.ToString();
+        }
     }
 }

--- a/src/Nethereum.Hex/HexTypes/HexBigInteger.cs
+++ b/src/Nethereum.Hex/HexTypes/HexBigInteger.cs
@@ -27,7 +27,7 @@ namespace Nethereum.Hex.HexTypes
 
         public override string ToString()
         {
-            return value.ToString();
+            return Value.ToString();
         }
     }
 }

--- a/src/Nethereum.Util.UnitTests/HexBigIntegerTests.cs
+++ b/src/Nethereum.Util.UnitTests/HexBigIntegerTests.cs
@@ -10,6 +10,8 @@ namespace Nethereum.Util.UnitTests
         {
             Assert.Equal("1000", new HexBigInteger(1000).ToString());
             Assert.Equal("1000", $"{new HexBigInteger(1000)}");
+            Assert.Equal("0", $"{new HexBigInteger("0x")}");
+            Assert.Equal("0", $"{new HexBigInteger(null)}");
         }
     }
 }

--- a/src/Nethereum.Util.UnitTests/HexBigIntegerTests.cs
+++ b/src/Nethereum.Util.UnitTests/HexBigIntegerTests.cs
@@ -1,0 +1,15 @@
+﻿using Nethereum.Hex.HexTypes;
+using Xunit;
+
+namespace Nethereum.Util.UnitTests
+{
+    public class HexBigIntegerTests
+    {
+        [Fact]
+        public void ToStringReturnsBigIntegerToString()
+        {
+            Assert.Equal("1000", new HexBigInteger(1000).ToString());
+            Assert.Equal("1000", $"{new HexBigInteger(1000)}");
+        }
+    }
+}

--- a/src/Nethereum.Util.UnitTests/HexBigIntegerTests.cs
+++ b/src/Nethereum.Util.UnitTests/HexBigIntegerTests.cs
@@ -1,4 +1,5 @@
-﻿using Nethereum.Hex.HexTypes;
+﻿using Nethereum.Hex.HexConvertors;
+using Nethereum.Hex.HexTypes;
 using Xunit;
 
 namespace Nethereum.Util.UnitTests
@@ -12,6 +13,7 @@ namespace Nethereum.Util.UnitTests
             Assert.Equal("1000", $"{new HexBigInteger(1000)}");
             Assert.Equal("0", $"{new HexBigInteger("0x")}");
             Assert.Equal("0", $"{new HexBigInteger(null)}");
+            Assert.Equal("1000", $"{new HexBigInteger("3E8")}");
         }
     }
 }


### PR DESCRIPTION
Every day I write debug or log code that logs the value of HexBigIntegers and often forget to reference the "Value" property.  It seems to make sense that the default "ToString" value should be the string representation of the internal BigInteger.  It would help debugging (hovering over the variable would show you the value) and logging (where you might have forgotten to reference the "Value" property.