### PR TITLE
Fix TransactionReceipt bug with empty status

### DIFF
--- a/src/Nethereum.RPC/Eth/DTOs/TransactionReceipt.cs
+++ b/src/Nethereum.RPC/Eth/DTOs/TransactionReceipt.cs
@@ -63,7 +63,7 @@ namespace Nethereum.RPC.Eth.DTOs
 
         public bool? HasErrors()
         {
-            if (Status == null) return null;
+            if (Status?.HexValue == null) return null;
             return Status.Value == 0;
         }
 


### PR DESCRIPTION
I debugged my app a lot to understand that `HasError()` reports `true` when there actually no errors.

For example here is my RPC request-responce:

```
2019-05-30 18:28:03.703 +03:00 [Verbose] [] [ v] RPC Request: {"id":1,"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x2b74c070fefa64304557dd5c77dd8c6f0b50205247d916e2b20c5374adb0c693"]}
2019-05-30 18:28:03.843 +03:00 [Verbose] [] [ v] RPC Response: {
  "blockHash": "0xbd8825b0f541f2effd2ba00dc6d452ef944da1b9d214e555eab35a232999cb9d",
  "blockNumber": "0x9e7bcf",
  "contractAddress": null,
  "cumulativeGasUsed": "0x87737",
  "from": "0x00fc2789a44a3355dbb455227bac5f223580ddbb",
  "gasUsed": "0x87737",
  "logs": [
    {
      "address": "0x87ac3af4aa4f7cb22f359cf85e9dc536bdf0ecd2",
      "blockHash": "0xbd8825b0f541f2effd2ba00dc6d452ef944da1b9d214e555eab35a232999cb9d",
      "blockNumber": "0x9e7bcf",
      "data": "0x0000000000000000000000000000000000000000000000000000000000004389000000000000000000000000000000000000000000000000000000000000000b",
      "logIndex": "0x0",
      "removed": false,
      "topics": [
        "0x422956473ce3321e3da3f92e760200a36fb3d4e5ba60d6fcc7c575b110884216"
      ],
      "transactionHash": "0x2b74c070fefa64304557dd5c77dd8c6f0b50205247d916e2b20c5374adb0c693",
      "transactionIndex": "0x0",
      "transactionLogIndex": "0x0",
      "type": "mined"
    }
  ],
  "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000200000000020000000000000000000000000000000000000000000000008000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  "root": null,
  "status": null,
  "to": "0x87ac3af4aa4f7cb22f359cf85e9dc536bdf0ecd2",
  "transactionHash": "0x2b74c070fefa64304557dd5c77dd8c6f0b50205247d916e2b20c5374adb0c693",
  "transactionIndex": "0x0"
}
```

And this is what I see in debugger:

![image](https://user-images.githubusercontent.com/11201122/58644515-16fb7280-830a-11e9-9507-ead68811ed4a.png)

Nethereum erroneously considers this to be an error when actually it's not.

Here is a fix to actually fix the issue