### PR TITLE
IEquatable HexBigInteger with tests

### DIFF
--- a/src/Nethereum.ABI.UnitTests/HexBigIntegerTests.cs
+++ b/src/Nethereum.ABI.UnitTests/HexBigIntegerTests.cs
@@ -1,7 +1,7 @@
 ﻿using Nethereum.Hex.HexTypes;
 using Xunit;
 
-namespace Nethereum.Util.UnitTests
+namespace Nethereum.ABI.UnitTests
 {
     public class HexBigIntegerTests
     {

--- a/src/Nethereum.Hex/HexTypes/HexBigInteger.cs
+++ b/src/Nethereum.Hex/HexTypes/HexBigInteger.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 namespace Nethereum.Hex.HexTypes
 {
     [JsonConverter(typeof(HexRPCTypeJsonConverter<HexBigInteger, BigInteger>))]
-    public class HexBigInteger : HexRPCType<BigInteger>, IEquatable<HexBigInteger>
+    public class HexBigInteger : HexRPCType<BigInteger>
     {
         public HexBigInteger(string hex) : base(new HexBigIntegerBigEndianConvertor(), hex)
         {
@@ -20,39 +20,12 @@ namespace Nethereum.Hex.HexTypes
         {
             if (obj is HexBigInteger val)
             {
-                return Equals(val);
+                return val.Value == Value;
             }
 
             return false;
         }
 
-        public bool Equals(HexBigInteger other)
-        {
-            return other == null ? false : other.Value == Value;
-        }
-
-        public static bool operator == (HexBigInteger lhs, HexBigInteger rhs)
-        {
-            // Check for null on left side.
-            if (Object.ReferenceEquals(lhs, null))
-            {
-                if (Object.ReferenceEquals(rhs, null))
-                {
-                    // null == null = true.
-                    return true;
-                }
-
-                // Only the left side is null.
-                return false;
-            }
-            // Equals handles case of null on right side.
-            return lhs.Equals(rhs);
-        }
-
-        public static bool operator != (HexBigInteger lhs, HexBigInteger rhs)
-        {
-            return !(lhs == rhs);
-        }
 
         public override string ToString()
         {

--- a/src/Nethereum.Hex/HexTypes/HexBigInteger.cs
+++ b/src/Nethereum.Hex/HexTypes/HexBigInteger.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using Nethereum.Hex.HexConvertors;
 using Newtonsoft.Json;
@@ -5,7 +6,7 @@ using Newtonsoft.Json;
 namespace Nethereum.Hex.HexTypes
 {
     [JsonConverter(typeof(HexRPCTypeJsonConverter<HexBigInteger, BigInteger>))]
-    public class HexBigInteger : HexRPCType<BigInteger>
+    public class HexBigInteger : HexRPCType<BigInteger>, IEquatable<HexBigInteger>
     {
         public HexBigInteger(string hex) : base(new HexBigIntegerBigEndianConvertor(), hex)
         {
@@ -19,10 +20,38 @@ namespace Nethereum.Hex.HexTypes
         {
             if (obj is HexBigInteger val)
             {
-                return val.Value == Value;
+                return Equals(val);
             }
 
             return false;
+        }
+
+        public bool Equals(HexBigInteger other)
+        {
+            return other == null ? false : other.Value == Value;
+        }
+
+        public static bool operator == (HexBigInteger lhs, HexBigInteger rhs)
+        {
+            // Check for null on left side.
+            if (Object.ReferenceEquals(lhs, null))
+            {
+                if (Object.ReferenceEquals(rhs, null))
+                {
+                    // null == null = true.
+                    return true;
+                }
+
+                // Only the left side is null.
+                return false;
+            }
+            // Equals handles case of null on right side.
+            return lhs.Equals(rhs);
+        }
+
+        public static bool operator != (HexBigInteger lhs, HexBigInteger rhs)
+        {
+            return !(lhs == rhs);
         }
 
         public override string ToString()

--- a/src/Nethereum.Hex/HexTypes/HexType.cs
+++ b/src/Nethereum.Hex/HexTypes/HexType.cs
@@ -4,7 +4,7 @@ using Nethereum.Hex.HexConvertors.Extensions;
 
 namespace Nethereum.Hex.HexTypes
 {
-    public class HexRPCType<T>
+    public class HexRPCType<T>: IEquatable<HexRPCType<T>>
     {
         protected IHexConvertor<T> convertor;
 
@@ -101,9 +101,37 @@ namespace Nethereum.Hex.HexTypes
             return hexRpcType.Value;
         }
 
+        public static bool operator == (HexRPCType<T> lhs, HexRPCType<T> rhs)
+        {
+            // Check for null on left side.
+            if (Object.ReferenceEquals(lhs, null))
+            {
+                if (Object.ReferenceEquals(rhs, null))
+                {
+                    // null == null = true.
+                    return true;
+                }
+
+                // Only the left side is null.
+                return false;
+            }
+            // Equals handles case of null on right side.
+            return lhs.Equals(rhs);
+        }
+
+        public static bool operator != (HexRPCType<T> lhs, HexRPCType<T> rhs)
+        {
+            return !(lhs == rhs);
+        }
+
         public override int GetHashCode()
         {
             return Value.GetHashCode();
+        }
+
+        public bool Equals(HexRPCType<T> other)
+        {
+            return other == null  ? false : Value.Equals(other.Value);
         }
     }
 }

--- a/src/Nethereum.Hex/HexTypes/HexType.cs
+++ b/src/Nethereum.Hex/HexTypes/HexType.cs
@@ -104,9 +104,9 @@ namespace Nethereum.Hex.HexTypes
         public static bool operator == (HexRPCType<T> lhs, HexRPCType<T> rhs)
         {
             // Check for null on left side.
-            if (Object.ReferenceEquals(lhs, null))
+            if (lhs is null)
             {
-                if (Object.ReferenceEquals(rhs, null))
+                if (rhs is null)
                 {
                     // null == null = true.
                     return true;

--- a/src/Nethereum.Util.UnitTests/HexBigIntegerTests.cs
+++ b/src/Nethereum.Util.UnitTests/HexBigIntegerTests.cs
@@ -1,5 +1,4 @@
-﻿using Nethereum.Hex.HexConvertors;
-using Nethereum.Hex.HexTypes;
+﻿using Nethereum.Hex.HexTypes;
 using Xunit;
 
 namespace Nethereum.Util.UnitTests
@@ -15,5 +14,50 @@ namespace Nethereum.Util.UnitTests
             Assert.Equal("0", $"{new HexBigInteger(null)}");
             Assert.Equal("1000", $"{new HexBigInteger("3E8")}");
         }
+
+        [Fact]
+        public void TwoHexBigIntegersWithTheSameValueAreEqual()
+        {
+            var val1 = new HexBigInteger(100);
+            var val2 = new HexBigInteger(100);
+
+            Assert.Equal(val1, val2);
+            Assert.True(val1 == val2);
+            Assert.True(val1.Equals(val2));
+        }
+
+        [Fact]
+        public void TwoHexBigIntegersWithDifferingValuesAreNotEqual()
+        {
+            var val1 = new HexBigInteger(100);
+            var val2 = new HexBigInteger(101);
+
+            Assert.NotEqual(val1, val2);
+        }
+
+        [Fact]
+        public void TwoNullHexBigIntegersAreEqual()
+        {
+            HexBigInteger val1 = null;
+            HexBigInteger val2 = null;
+
+            Assert.Equal(val1, val2);
+        }
+
+        [Fact]
+        public void ANonNullHexBigIntegerIsNotEqualToANull()
+        {
+            var nonNull = new HexBigInteger(100);
+            HexBigInteger nullHexBigInteger = null;
+
+            Assert.NotEqual(nonNull, nullHexBigInteger);
+            Assert.NotEqual(nullHexBigInteger, nonNull);
+            Assert.False(nonNull == nullHexBigInteger);
+            Assert.False(nullHexBigInteger == nonNull);
+            Assert.True(nonNull != nullHexBigInteger);
+            Assert.True(nullHexBigInteger != nonNull);
+        }
+
+
     }
 }


### PR DESCRIPTION
Whilst testing the processor I noticed that HexBigInteger comparisons didn't always work as expected.  Mainly the operator "==" didn't work as expected (Equals did).  For me it created a problem with unit testing and mocking out RPC calls and it will probably catch others out.   I have implemented IEquatable to support "==" and "!=" with tests.  Creating a pull just in case there are some side effects I am not aware of.