### PR TITLE
IBlockchainBlockProcessingService - New Block processor overloads

### DIFF
--- a/src/Nethereum.BlockchainProcessing.IntegrationTests/BlockProcessing/BlockProcessingTests.cs
+++ b/src/Nethereum.BlockchainProcessing.IntegrationTests/BlockProcessing/BlockProcessingTests.cs
@@ -143,7 +143,7 @@ namespace Nethereum.BlockchainProcessing.IntegrationTests.BlockProcessing
 
             var cancellationTokenSource = new CancellationTokenSource();
 
-            var blockProcessor = Web3.Processing.Blocks.CreateBlockProcessor(steps =>
+            var blockProcessor = Web3.Processing.Blocks.CreateBlockProcessor(progressRepository, steps =>
             {
                 //capture a block and then cancel
                 steps.BlockStep.AddSynchronousProcessorHandler((block) => {
@@ -151,7 +151,7 @@ namespace Nethereum.BlockchainProcessing.IntegrationTests.BlockProcessing
                     cancellationTokenSource.Cancel();
                 });
             }
-            , progressRepository);
+            );
 
             await blockProcessor.ExecuteAsync(cancellationTokenSource.Token);
 
@@ -175,7 +175,7 @@ namespace Nethereum.BlockchainProcessing.IntegrationTests.BlockProcessing
             var cancellationTokenSource = new CancellationTokenSource();
             var processedData = new ProcessedBlockchainData();
 
-            var blockProcessor = Web3.Processing.Blocks.CreateBlockProcessor(steps =>
+            var blockProcessor = Web3.Processing.Blocks.CreateBlockProcessor(progressRepository, steps =>
             {
                 //capture a block and then cancel
                 steps.BlockStep.AddSynchronousProcessorHandler((block) => {
@@ -183,7 +183,7 @@ namespace Nethereum.BlockchainProcessing.IntegrationTests.BlockProcessing
                     cancellationTokenSource.Cancel();
                 });
             }
-            , progressRepository);
+            );
 
 
             await blockProcessor.ExecuteAsync(cancellationTokenSource.Token, minBlock);
@@ -198,7 +198,7 @@ namespace Nethereum.BlockchainProcessing.IntegrationTests.BlockProcessing
         {
             var blockLastProcessed = new BigInteger(100);
             var nextBlock = blockLastProcessed + 1;
-            const uint MIN_CONFIRMATIONS = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS;
+            const uint MIN_CONFIRMATIONS = 12;
 
             var progressRepository = new InMemoryBlockchainProgressRepository(blockLastProcessed);
 
@@ -213,7 +213,7 @@ namespace Nethereum.BlockchainProcessing.IntegrationTests.BlockProcessing
             var cancellationTokenSource = new CancellationTokenSource();
             var processedData = new ProcessedBlockchainData();
 
-            var blockProcessor = Web3.Processing.Blocks.CreateBlockProcessor(steps =>
+            var blockProcessor = Web3.Processing.Blocks.CreateBlockProcessor(progressRepository, steps =>
             {
                 //capture a block and then cancel
                 steps.BlockStep.AddSynchronousProcessorHandler((block) => {
@@ -221,7 +221,7 @@ namespace Nethereum.BlockchainProcessing.IntegrationTests.BlockProcessing
                     cancellationTokenSource.Cancel();
                 });
             }
-            , progressRepository);
+            , MIN_CONFIRMATIONS);
 
 
             await blockProcessor.ExecuteAsync(cancellationTokenSource.Token);

--- a/src/Nethereum.BlockchainProcessing/BlockProcessing/BlockCrawlOrchestrator.cs
+++ b/src/Nethereum.BlockchainProcessing/BlockProcessing/BlockCrawlOrchestrator.cs
@@ -24,6 +24,12 @@ namespace Nethereum.BlockchainProcessing.BlockProcessing
 
         public FilterLogCrawlerStep FilterLogCrawlerStep { get; }
 
+        public BlockCrawlOrchestrator(IEthApiContractService ethApi, BlockProcessingSteps blockProcessingSteps)
+            :this(ethApi, new[] { blockProcessingSteps })
+        {
+
+        }
+
         public BlockCrawlOrchestrator(IEthApiContractService ethApi, IEnumerable<BlockProcessingSteps> processingStepsCollection)
         {
             

--- a/src/Nethereum.BlockchainProcessing/LogProcessing/BlockRangeRequestStrategy.cs
+++ b/src/Nethereum.BlockchainProcessing/LogProcessing/BlockRangeRequestStrategy.cs
@@ -15,7 +15,7 @@ namespace Nethereum.BlockchainProcessing.LogProcessing
 
         public BigInteger GeBlockNumberToRequestTo(BigInteger fromBlockNumber, BigInteger maxBlockNumberToRequestTo, int retryRequestNumber = 0)
         {
-            var totalNumberOfBlocksRequested = (int)(fromBlockNumber - maxBlockNumberToRequestTo + 1);
+            var totalNumberOfBlocksRequested = (int)(maxBlockNumberToRequestTo - fromBlockNumber) + 1;
 
             var maxNumberOfBlocks = _defaultNumberOfBlocksPerRequest;
 

--- a/src/Nethereum.BlockchainProcessing/ProgressRepositories/InMemoryBlockchainProgressRepository.cs
+++ b/src/Nethereum.BlockchainProcessing/ProgressRepositories/InMemoryBlockchainProgressRepository.cs
@@ -5,14 +5,19 @@ namespace Nethereum.BlockchainProcessing.ProgressRepositories
 {
     public class InMemoryBlockchainProgressRepository : IBlockProgressRepository
     {
-        public InMemoryBlockchainProgressRepository(BigInteger? lastBlockProcessed)
+        public InMemoryBlockchainProgressRepository()
+        {
+
+        }
+
+        public InMemoryBlockchainProgressRepository(BigInteger lastBlockProcessed)
         {
             LastBlockProcessed = lastBlockProcessed;
         }
 
         public BigInteger? LastBlockProcessed { get; private set;}
 
-        public Task<BigInteger?> GetLastBlockNumberProcessedAsync() => Task.FromResult((BigInteger?)LastBlockProcessed);
+        public Task<BigInteger?> GetLastBlockNumberProcessedAsync() => Task.FromResult(LastBlockProcessed);
 
         public Task UpsertProgressAsync(BigInteger blockNumber)
         {

--- a/src/Nethereum.BlockchainProcessing/Services/BlockchainBlockProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/BlockchainBlockProcessingService.cs
@@ -22,28 +22,11 @@ namespace Nethereum.BlockchainProcessing.Services
 
         public BlockchainProcessor CreateBlockProcessor(
             Action<BlockProcessingSteps> stepsConfiguration, 
-            ILog log = null) => CreateBlockProcessor(
-                stepsConfiguration, 
-                LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS, 
-                log);
-
-        public BlockchainProcessor CreateBlockProcessor(
-            Action<BlockProcessingSteps> stepsConfiguration, 
-            uint minimumBlockConfirmations, 
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS, 
             ILog log = null) => CreateBlockProcessor(
                 new InMemoryBlockchainProgressRepository(lastBlockProcessed: null),
                 stepsConfiguration, 
                 minimumBlockConfirmations, 
-                log);
-
-
-        public BlockchainProcessor CreateBlockProcessor(
-            IBlockProgressRepository blockProgressRepository, 
-            Action<BlockProcessingSteps> stepsConfiguration, 
-            ILog log = null) => CreateBlockProcessor(
-                blockProgressRepository, 
-                stepsConfiguration, 
-                LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS, 
                 log);
 
         public BlockchainProcessor CreateBlockProcessor(
@@ -61,19 +44,9 @@ namespace Nethereum.BlockchainProcessing.Services
             return new BlockchainProcessor(orchestrator, blockProgressRepository, lastConfirmedBlockNumberService, log);
         }
 
-
         public BlockchainProcessor CreateBlockStorageProcessor(
             IBlockchainStoreRepositoryFactory blockchainStorageFactory, 
-            Action<BlockProcessingSteps> configureSteps = null, 
-            ILog log = null) => CreateBlockStorageProcessor(
-                blockchainStorageFactory, 
-                LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS, 
-                configureSteps, 
-                log);
-
-        public BlockchainProcessor CreateBlockStorageProcessor(
-            IBlockchainStoreRepositoryFactory blockchainStorageFactory, 
-            uint minimumBlockConfirmations, 
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS, 
             Action<BlockProcessingSteps> configureSteps = null, 
             ILog log = null) => CreateBlockStorageProcessor(
                 blockchainStorageFactory, 
@@ -82,21 +55,11 @@ namespace Nethereum.BlockchainProcessing.Services
                 configureSteps, 
                 log);
 
-        public BlockchainProcessor CreateBlockStorageProcessor(
-            IBlockchainStoreRepositoryFactory blockchainStorageFactory, 
-            IBlockProgressRepository blockProgressRepository, 
-            Action<BlockProcessingSteps> configureSteps = null, 
-            ILog log = null) => CreateBlockStorageProcessor(
-                blockchainStorageFactory, 
-                blockProgressRepository, 
-                LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS, 
-                configureSteps, 
-                log);
 
         public BlockchainProcessor CreateBlockStorageProcessor(
             IBlockchainStoreRepositoryFactory blockchainStorageFactory,
             IBlockProgressRepository blockProgressRepository,
-            uint minimumBlockConfirmations,
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Action<BlockProcessingSteps> configureSteps = null,
             ILog log = null)
         {

--- a/src/Nethereum.BlockchainProcessing/Services/BlockchainBlockProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/BlockchainBlockProcessingService.cs
@@ -1,4 +1,5 @@
 using System;
+using Common.Logging;
 using Nethereum.BlockchainProcessing.BlockProcessing;
 using Nethereum.BlockchainProcessing.BlockStorage;
 using Nethereum.BlockchainProcessing.BlockStorage.Repositories;
@@ -20,23 +21,62 @@ namespace Nethereum.BlockchainProcessing.Services
 #if !DOTNET35
         public BlockchainProcessor CreateBlockProcessor(
             Action<BlockProcessingSteps> stepsConfiguration = null,
-            IBlockProgressRepository blockProgressRepository = null)
+            uint? minimumBlockConfirmations = null,
+            uint? lastBlockNumberProcessed = null,
+            ILog log = null)
         {
             var processingSteps = new BlockProcessingSteps();
             var orchestrator = new BlockCrawlOrchestrator(_ethApiContractService, new[] { processingSteps });
-            var progressRepository = blockProgressRepository ??
-                                     new InMemoryBlockchainProgressRepository(lastBlockProcessed: null);
-            var lastConfirmedBlockNumberService =
-                new LastConfirmedBlockNumberService(_ethApiContractService.Blocks.GetBlockNumber);
+            var progressRepository = new InMemoryBlockchainProgressRepository(lastBlockProcessed: lastBlockNumberProcessed);
+
+            var lastConfirmedBlockNumberService = new LastConfirmedBlockNumberService(_ethApiContractService.Blocks.GetBlockNumber, minimumBlockConfirmations);
+
             stepsConfiguration?.Invoke(processingSteps);
-            return new BlockchainProcessor(orchestrator, progressRepository, lastConfirmedBlockNumberService);
+            return new BlockchainProcessor(orchestrator, progressRepository, lastConfirmedBlockNumberService, log);
         }
 
+        public BlockchainProcessor CreateBlockProcessor(
+            IBlockProgressRepository blockProgressRepository,
+            Action<BlockProcessingSteps> stepsConfiguration = null,
+            uint? minimumBlockConfirmations = null,
+            ILog log = null)
+        {
+            var processingSteps = new BlockProcessingSteps();
+            var orchestrator = new BlockCrawlOrchestrator(_ethApiContractService, new[] { processingSteps });
+            var progressRepository = blockProgressRepository ?? new InMemoryBlockchainProgressRepository(lastBlockProcessed: null);
+
+            var lastConfirmedBlockNumberService = new LastConfirmedBlockNumberService(_ethApiContractService.Blocks.GetBlockNumber, minimumBlockConfirmations);
+
+            stepsConfiguration?.Invoke(processingSteps);
+            return new BlockchainProcessor(orchestrator, progressRepository, lastConfirmedBlockNumberService, log);
+        }
 
         public BlockchainProcessor CreateBlockStorageProcessor(
             IBlockchainStoreRepositoryFactory blockchainStorageFactory,
             Action<BlockProcessingSteps> configureSteps = null,
-            IBlockProgressRepository blockProgressRepository = null)
+            uint? minimumBlockConfirmations = null,
+            uint? lastBlockNumberProcessed = null,
+            ILog log = null)
+        {
+            var processingSteps = new BlockStorageProcessingSteps(blockchainStorageFactory);
+            var orchestrator = new BlockCrawlOrchestrator(_ethApiContractService, new[] { processingSteps });
+
+            IBlockProgressRepository blockProgressRepository = null;
+
+            if (blockchainStorageFactory is IBlockProgressRepositoryFactory progressRepoFactory)
+            {
+                blockProgressRepository = progressRepoFactory.CreateBlockProgressRepository();
+            }
+
+            return CreateBlockProcessor(configureSteps, blockProgressRepository, processingSteps, minimumBlockConfirmations, lastBlockNumberProcessed, log);
+        }
+
+        public BlockchainProcessor CreateBlockStorageProcessor(
+            IBlockchainStoreRepositoryFactory blockchainStorageFactory,
+            IBlockProgressRepository blockProgressRepository,
+            Action<BlockProcessingSteps> configureSteps = null,
+            uint? minimumBlockConfirmations = null,
+            ILog log = null)
         {
             var processingSteps = new BlockStorageProcessingSteps(blockchainStorageFactory);
             var orchestrator = new BlockCrawlOrchestrator(_ethApiContractService, new[] { processingSteps });
@@ -46,18 +86,17 @@ namespace Nethereum.BlockchainProcessing.Services
                 blockProgressRepository = progressRepoFactory.CreateBlockProgressRepository();
             }
 
-            return CreateBlockProcessor(configureSteps, blockProgressRepository, processingSteps);
+            return CreateBlockProcessor(configureSteps, blockProgressRepository, processingSteps, minimumBlockConfirmations, lastBlockNumberProcessed: null, log);
         }
 
-        private BlockchainProcessor CreateBlockProcessor(Action<BlockProcessingSteps> configureSteps, IBlockProgressRepository blockProgressRepository, BlockProcessingSteps processingSteps)
+        private BlockchainProcessor CreateBlockProcessor(Action<BlockProcessingSteps> configureSteps, IBlockProgressRepository blockProgressRepository, BlockProcessingSteps processingSteps, uint? minimumBlockConfirmations, uint? lastBlockNumberProcessed, ILog log)
         {
             var orchestrator = new BlockCrawlOrchestrator(_ethApiContractService, new[] { processingSteps });
-            var progressRepository = blockProgressRepository ?? new InMemoryBlockchainProgressRepository(lastBlockProcessed: null);
-            var lastConfirmedBlockNumberService = new LastConfirmedBlockNumberService(_ethApiContractService.Blocks.GetBlockNumber);
-
+            var progressRepository = blockProgressRepository ?? new InMemoryBlockchainProgressRepository(lastBlockProcessed: lastBlockNumberProcessed);
+            var lastConfirmedBlockNumberService = new LastConfirmedBlockNumberService(_ethApiContractService.Blocks.GetBlockNumber, minimumBlockConfirmations);
             configureSteps?.Invoke(processingSteps);
 
-            return new BlockchainProcessor(orchestrator, progressRepository, lastConfirmedBlockNumberService);
+            return new BlockchainProcessor(orchestrator, progressRepository, lastConfirmedBlockNumberService, log);
         }
 #endif
     }

--- a/src/Nethereum.BlockchainProcessing/Services/BlockchainLogProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/BlockchainLogProcessingService.cs
@@ -146,7 +146,7 @@ namespace Nethereum.BlockchainProcessing.Services
             var orchestrator = new LogOrchestrator(_ethApiContractService, logProcessors, filter);
 
             var progressRepository = blockProgressRepository ??
-                                     new InMemoryBlockchainProgressRepository(lastBlockProcessed: null);
+                                     new InMemoryBlockchainProgressRepository();
             var lastConfirmedBlockNumberService =
                 new LastConfirmedBlockNumberService(_ethApiContractService.Blocks.GetBlockNumber);
 

--- a/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
@@ -1,4 +1,5 @@
 using System;
+using Common.Logging;
 using Nethereum.BlockchainProcessing.BlockProcessing;
 using Nethereum.BlockchainProcessing.BlockStorage.Repositories;
 using Nethereum.BlockchainProcessing.ProgressRepositories;
@@ -15,11 +16,28 @@ namespace Nethereum.BlockchainProcessing.Services
     {
         BlockchainProcessor CreateBlockProcessor(
             Action<BlockProcessingSteps> stepsConfiguration = null,
-            IBlockProgressRepository blockProgressRepository = null);
+            uint? minimumBlockConfirmations = null,
+            uint? lastBlockNumberProcessed = null,
+            ILog log = null);
+
+        BlockchainProcessor CreateBlockProcessor(
+            IBlockProgressRepository blockProgressRepository,
+            Action<BlockProcessingSteps> stepsConfiguration = null,
+            uint? minimumBlockConfirmations = null,
+            ILog log = null);
 
         BlockchainProcessor CreateBlockStorageProcessor(
             IBlockchainStoreRepositoryFactory blockchainStorageFactory,
             Action<BlockProcessingSteps> configureSteps = null,
-            IBlockProgressRepository blockProgressRepository = null);
+            uint? minimumBlockConfirmations = null,
+            uint? lastBlockNumberProcessed = null,
+            ILog log = null);
+
+        BlockchainProcessor CreateBlockStorageProcessor(
+            IBlockchainStoreRepositoryFactory blockchainStorageFactory,
+            IBlockProgressRepository blockProgressRepository,
+            Action<BlockProcessingSteps> configureSteps = null,
+            uint? minimumBlockConfirmations = null,
+            ILog log = null);
     }
 }

--- a/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
@@ -14,47 +14,30 @@ namespace Nethereum.BlockchainProcessing.Services
 
     public interface IBlockchainBlockProcessingService
     {
-        BlockchainProcessor CreateBlockProcessor(
-            Action<BlockProcessingSteps> stepsConfiguration,
-            ILog log = null);
 
         BlockchainProcessor CreateBlockProcessor(
             Action<BlockProcessingSteps> stepsConfiguration,
-            uint minimumBlockConfirmations,
+            uint minimumBlockConfirmations = default,
             ILog log = null);
+
 
         BlockchainProcessor CreateBlockProcessor(
             IBlockProgressRepository blockProgressRepository,
             Action<BlockProcessingSteps> stepsConfiguration,
+            uint minimumBlockConfirmations = default,
             ILog log = null);
 
-        BlockchainProcessor CreateBlockProcessor(
-            IBlockProgressRepository blockProgressRepository,
-            Action<BlockProcessingSteps> stepsConfiguration,
-            uint minimumBlockConfirmations,
-            ILog log = null);
 
         BlockchainProcessor CreateBlockStorageProcessor(
             IBlockchainStoreRepositoryFactory blockchainStorageFactory,
-            Action<BlockProcessingSteps> configureSteps = null,
-            ILog log = null);
-
-        BlockchainProcessor CreateBlockStorageProcessor(
-            IBlockchainStoreRepositoryFactory blockchainStorageFactory,
-            uint minimumBlockConfirmations,
+            uint minimumBlockConfirmations = default,
             Action<BlockProcessingSteps> configureSteps = null,
             ILog log = null);
 
         BlockchainProcessor CreateBlockStorageProcessor(
             IBlockchainStoreRepositoryFactory blockchainStorageFactory,
             IBlockProgressRepository blockProgressRepository,
-            Action<BlockProcessingSteps> configureSteps = null,
-            ILog log = null);
-
-        BlockchainProcessor CreateBlockStorageProcessor(
-            IBlockchainStoreRepositoryFactory blockchainStorageFactory,
-            IBlockProgressRepository blockProgressRepository,
-            uint minimumBlockConfirmations,
+            uint minimumBlockConfirmations = default,
             Action<BlockProcessingSteps> configureSteps = null,
             ILog log = null);
     }

--- a/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
@@ -15,29 +15,47 @@ namespace Nethereum.BlockchainProcessing.Services
     public interface IBlockchainBlockProcessingService
     {
         BlockchainProcessor CreateBlockProcessor(
-            Action<BlockProcessingSteps> stepsConfiguration = null,
-            uint? minimumBlockConfirmations = null,
-            uint? lastBlockNumberProcessed = null,
+            Action<BlockProcessingSteps> stepsConfiguration,
+            ILog log = null);
+
+        BlockchainProcessor CreateBlockProcessor(
+            Action<BlockProcessingSteps> stepsConfiguration,
+            uint minimumBlockConfirmations,
             ILog log = null);
 
         BlockchainProcessor CreateBlockProcessor(
             IBlockProgressRepository blockProgressRepository,
-            Action<BlockProcessingSteps> stepsConfiguration = null,
-            uint? minimumBlockConfirmations = null,
+            Action<BlockProcessingSteps> stepsConfiguration,
+            ILog log = null);
+
+        BlockchainProcessor CreateBlockProcessor(
+            IBlockProgressRepository blockProgressRepository,
+            Action<BlockProcessingSteps> stepsConfiguration,
+            uint minimumBlockConfirmations,
             ILog log = null);
 
         BlockchainProcessor CreateBlockStorageProcessor(
             IBlockchainStoreRepositoryFactory blockchainStorageFactory,
             Action<BlockProcessingSteps> configureSteps = null,
-            uint? minimumBlockConfirmations = null,
-            uint? lastBlockNumberProcessed = null,
+            ILog log = null);
+
+        BlockchainProcessor CreateBlockStorageProcessor(
+            IBlockchainStoreRepositoryFactory blockchainStorageFactory,
+            uint minimumBlockConfirmations,
+            Action<BlockProcessingSteps> configureSteps = null,
             ILog log = null);
 
         BlockchainProcessor CreateBlockStorageProcessor(
             IBlockchainStoreRepositoryFactory blockchainStorageFactory,
             IBlockProgressRepository blockProgressRepository,
             Action<BlockProcessingSteps> configureSteps = null,
-            uint? minimumBlockConfirmations = null,
+            ILog log = null);
+
+        BlockchainProcessor CreateBlockStorageProcessor(
+            IBlockchainStoreRepositoryFactory blockchainStorageFactory,
+            IBlockProgressRepository blockProgressRepository,
+            uint minimumBlockConfirmations,
+            Action<BlockProcessingSteps> configureSteps = null,
             ILog log = null);
     }
 }

--- a/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
@@ -21,7 +21,6 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             ILog log = null);
 
-
         BlockchainProcessor CreateBlockProcessor(
             IBlockProgressRepository blockProgressRepository,
             Action<BlockProcessingSteps> stepsConfiguration,

--- a/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
@@ -3,6 +3,7 @@ using Common.Logging;
 using Nethereum.BlockchainProcessing.BlockProcessing;
 using Nethereum.BlockchainProcessing.BlockStorage.Repositories;
 using Nethereum.BlockchainProcessing.ProgressRepositories;
+using Nethereum.RPC.Eth.Blocks;
 
 namespace Nethereum.BlockchainProcessing.Services
 {
@@ -17,27 +18,27 @@ namespace Nethereum.BlockchainProcessing.Services
 
         BlockchainProcessor CreateBlockProcessor(
             Action<BlockProcessingSteps> stepsConfiguration,
-            uint minimumBlockConfirmations = default,
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             ILog log = null);
 
 
         BlockchainProcessor CreateBlockProcessor(
             IBlockProgressRepository blockProgressRepository,
             Action<BlockProcessingSteps> stepsConfiguration,
-            uint minimumBlockConfirmations = default,
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             ILog log = null);
 
 
         BlockchainProcessor CreateBlockStorageProcessor(
             IBlockchainStoreRepositoryFactory blockchainStorageFactory,
-            uint minimumBlockConfirmations = default,
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Action<BlockProcessingSteps> configureSteps = null,
             ILog log = null);
 
         BlockchainProcessor CreateBlockStorageProcessor(
             IBlockchainStoreRepositoryFactory blockchainStorageFactory,
             IBlockProgressRepository blockProgressRepository,
-            uint minimumBlockConfirmations = default,
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Action<BlockProcessingSteps> configureSteps = null,
             ILog log = null);
     }

--- a/src/Nethereum.RPC/Eth/Blocks/LastConfirmedBlockNumberService.cs
+++ b/src/Nethereum.RPC/Eth/Blocks/LastConfirmedBlockNumberService.cs
@@ -19,7 +19,7 @@ namespace Nethereum.RPC.Eth.Blocks
 
         public LastConfirmedBlockNumberService(
             IEthBlockNumber ethBlockNumber,
-            uint? minimumBlockConfirmations = null,
+            uint minimumBlockConfirmations = DEFAULT_BLOCK_CONFIRMATIONS,
             ILog log = null,
             IWaitStrategy waitStrategy = null
             ) : this(
@@ -34,13 +34,13 @@ namespace Nethereum.RPC.Eth.Blocks
         public LastConfirmedBlockNumberService(
             IEthBlockNumber ethBlockNumber,
             IWaitStrategy waitStrategy,
-            uint? minimumBlockConfirmations = null,
+            uint minimumBlockConfirmations = DEFAULT_BLOCK_CONFIRMATIONS,
             ILog log = null
             )
         {
             _ethBlockNumber = ethBlockNumber;
             _waitStrategy = waitStrategy;
-            _minimumBlockConfirmations = minimumBlockConfirmations ?? DEFAULT_BLOCK_CONFIRMATIONS;
+            _minimumBlockConfirmations = minimumBlockConfirmations;
             _log = log;
         }
 

--- a/src/Nethereum.RPC/Eth/Blocks/LastConfirmedBlockNumberService.cs
+++ b/src/Nethereum.RPC/Eth/Blocks/LastConfirmedBlockNumberService.cs
@@ -19,7 +19,7 @@ namespace Nethereum.RPC.Eth.Blocks
 
         public LastConfirmedBlockNumberService(
             IEthBlockNumber ethBlockNumber,
-            uint minimumBlockConfirmations = DEFAULT_BLOCK_CONFIRMATIONS,
+            uint? minimumBlockConfirmations = null,
             ILog log = null,
             IWaitStrategy waitStrategy = null
             ) : this(
@@ -34,13 +34,13 @@ namespace Nethereum.RPC.Eth.Blocks
         public LastConfirmedBlockNumberService(
             IEthBlockNumber ethBlockNumber,
             IWaitStrategy waitStrategy,
-            uint minimumBlockConfirmations = DEFAULT_BLOCK_CONFIRMATIONS,
+            uint? minimumBlockConfirmations = null,
             ILog log = null
             )
         {
             _ethBlockNumber = ethBlockNumber;
             _waitStrategy = waitStrategy;
-            _minimumBlockConfirmations = minimumBlockConfirmations;
+            _minimumBlockConfirmations = minimumBlockConfirmations ?? DEFAULT_BLOCK_CONFIRMATIONS;
             _log = log;
         }
 


### PR DESCRIPTION
New CreateBlockProcessor and CreateBlockStorageProcessor methods to provide more flexibility.  Old method signatures have been changed to provide clarity.

The default of 12 block confirmations seemed quite high for some scenarios - so providing an optional parameter makes sense.

Last block processed is only on the methods that do not accept a progress repository.   It allows the in-memory default repo to be configured.  

Not having an ILog parameter was probably an oversight previously.  Added as an optional parameter.