### PR TITLE
Remove Potential InvalidOperationException in ContractCreatedCrawlerStep

### DIFF
--- a/src/Nethereum.BlockchainProcessing/BlockProcessing/CrawlerSteps/ContractCreatedCrawlerStep.cs
+++ b/src/Nethereum.BlockchainProcessing/BlockProcessing/CrawlerSteps/ContractCreatedCrawlerStep.cs
@@ -22,7 +22,7 @@ namespace Nethereum.BlockchainProcessing.BlockProcessing.CrawlerSteps
                 hasFailed = HasFailedToCreateContract(code);
             }
             return new ContractCreationVO(transactionReceiptVO, code,
-                hasFailed.Value);
+                hasFailed ?? false);
         }
 
         protected virtual bool HasFailedToCreateContract(string code)


### PR DESCRIPTION
The chain I am crawling throws an InvalidOperationException at line 24-25 because hasFailed is null. I defaulted the value to false based on similar logic in TransactionReceiptCrawlerStep.