### PR TITLE
LogProcessing option to pass BlockRangeRequestStrategy

### DIFF
--- a/src/Nethereum.BlockchainProcessing.UnitTests/LogProcessing/LogOrchestratorTests.cs
+++ b/src/Nethereum.BlockchainProcessing.UnitTests/LogProcessing/LogOrchestratorTests.cs
@@ -28,6 +28,25 @@ namespace Nethereum.BlockchainProcessing.UnitTests.LogProcessing
         }
 
         [Fact]
+        public void BlockRangeRequestStrategy_Is_Defaulted_When_Not_Explicity_Set()
+        {
+            _logOrchestrator = new LogOrchestrator(_web3Mock.EthApiContractServiceMock.Object, new[] { _logHandler }, null, 100, 1);
+            var actualStrategy = _logOrchestrator.BlockRangeRequestStrategy as BlockRangeRequestStrategy;
+            Assert.NotNull(actualStrategy);
+            Assert.Equal(100, actualStrategy.DefaultNumberOfBlocksPerRequest);
+            Assert.Equal(1, actualStrategy.RetryWeight);
+        }
+
+        [Fact]
+        public void BlockRangeRequestStrategy_Can_Be_Injected()
+        {
+            var blockRangeRequestStrategy = new BlockRangeRequestStrategy();
+            _logOrchestrator = new LogOrchestrator(_web3Mock.EthApiContractServiceMock.Object, new[] { _logHandler }, null, blockRangeRequestStrategy);
+            Assert.Same(blockRangeRequestStrategy, _logOrchestrator.BlockRangeRequestStrategy);
+        }
+
+
+        [Fact]
         public async Task Should_Retrieve_Logs_And_Invoke_Handlers_And_Report_Last_Block_Processed()
         {
             var fromBlock = new BigInteger(10);

--- a/src/Nethereum.BlockchainProcessing/LogProcessing/BlockRangeRequestStrategy.cs
+++ b/src/Nethereum.BlockchainProcessing/LogProcessing/BlockRangeRequestStrategy.cs
@@ -2,31 +2,32 @@
 
 namespace Nethereum.BlockchainProcessing.LogProcessing
 {
-    public class BlockRangeRequestStrategy
+    public class BlockRangeRequestStrategy : IBlockRangeRequestStrategy
     {
-        private readonly int _defaultNumberOfBlocksPerRequest;
-        private readonly int _retryWeight;
+        public int DefaultNumberOfBlocksPerRequest {get; }
+        public int RetryWeight {get; }
 
         public BlockRangeRequestStrategy(int defaultNumberOfBlocksPerRequest = 100, int retryWeight = 0)
         {
-            _defaultNumberOfBlocksPerRequest = defaultNumberOfBlocksPerRequest;
-            _retryWeight = retryWeight;
+            DefaultNumberOfBlocksPerRequest = defaultNumberOfBlocksPerRequest;
+            RetryWeight = retryWeight;
         }
 
         public BigInteger GeBlockNumberToRequestTo(BigInteger fromBlockNumber, BigInteger maxBlockNumberToRequestTo, int retryRequestNumber = 0)
         {
-            var totalNumberOfBlocksRequested = (int)(maxBlockNumberToRequestTo - fromBlockNumber) + 1;
+            var blocksRequested = (int)(maxBlockNumberToRequestTo - fromBlockNumber) + 1;
 
-            var maxNumberOfBlocks = _defaultNumberOfBlocksPerRequest;
+            var maxNumberOfBlocks = DefaultNumberOfBlocksPerRequest;
 
-            //we start with the smaller batch instead if we only need less than the total batch
-            if (totalNumberOfBlocksRequested < maxNumberOfBlocks)
+            // block size is lower than max
+            if (blocksRequested < maxNumberOfBlocks)
             {
-                maxNumberOfBlocks = totalNumberOfBlocksRequested;
+                maxNumberOfBlocks = blocksRequested;
             }
 
             if (retryRequestNumber > 0)
             {
+                //reduce block range relative to retry number
                 maxNumberOfBlocks = GetMaxNumberOfBlocksToRequestToRetryAttempt(retryRequestNumber, maxNumberOfBlocks);
             }
 
@@ -51,7 +52,7 @@ namespace Nethereum.BlockchainProcessing.LogProcessing
 
         protected virtual int GetMaxNumberOfBlocksToRequestToRetryAttempt(int retryRequestNumber, int numberOfBlocksPerRequest)
         {
-            return numberOfBlocksPerRequest / (retryRequestNumber + 1) + (_retryWeight * retryRequestNumber);
+            return numberOfBlocksPerRequest / (retryRequestNumber + 1) + (RetryWeight * retryRequestNumber);
         }
     }
 }

--- a/src/Nethereum.BlockchainProcessing/LogProcessing/IBlockRangeRequestStrategy.cs
+++ b/src/Nethereum.BlockchainProcessing/LogProcessing/IBlockRangeRequestStrategy.cs
@@ -1,0 +1,9 @@
+﻿using System.Numerics;
+
+namespace Nethereum.BlockchainProcessing.LogProcessing
+{
+    public interface IBlockRangeRequestStrategy
+    {
+        BigInteger GeBlockNumberToRequestTo(BigInteger fromBlockNumber, BigInteger maxBlockNumberToRequestTo, int retryRequestNumber = 0);
+    }
+}

--- a/src/Nethereum.BlockchainProcessing/Services/BlockchainLogProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/BlockchainLogProcessingService.cs
@@ -26,9 +26,15 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations,
             Func<EventLog<TEventDTO>, bool> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new() =>
-            CreateProcessor(new[] {new EventLogProcessorHandler<TEventDTO>(action, criteria)}, minimumBlockConfirmations,
-                new FilterInputBuilder<TEventDTO>().Build(), blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new() =>
+                CreateProcessor(
+                    new[] {new EventLogProcessorHandler<TEventDTO>(action, criteria)}, 
+                    minimumBlockConfirmations,
+                    new FilterInputBuilder<TEventDTO>().Build(), 
+                    blockProgressRepository, 
+                    log, 
+                    blockRangeRequestStrategy);
 
 
         public BlockchainProcessor CreateProcessorForContract<TEventDTO>(
@@ -37,16 +43,21 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations,
             Func<EventLog<TEventDTO>, bool> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new() =>
-            CreateProcessor(new[]
-            {
-                new EventLogProcessorHandler<TEventDTO>(action, criteria)
-            },
-                minimumBlockConfirmations,
-                new FilterInputBuilder<TEventDTO>().Build(new[]
-            {
-                contractAddress
-            }), blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new() =>
+                CreateProcessor(
+                    new[]
+                    {
+                        new EventLogProcessorHandler<TEventDTO>(action, criteria)
+                    },
+                    minimumBlockConfirmations,
+                    new FilterInputBuilder<TEventDTO>().Build(new[]
+                    {
+                        contractAddress
+                    }), 
+                    blockProgressRepository, 
+                    log, 
+                    blockRangeRequestStrategy);
 
 
         public BlockchainProcessor CreateProcessorForContracts<TEventDTO>(
@@ -55,18 +66,30 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations,
             Func<EventLog<TEventDTO>, bool> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new() =>
-            CreateProcessor(new[] {new EventLogProcessorHandler<TEventDTO>(action, criteria)}, minimumBlockConfirmations,
-                new FilterInputBuilder<TEventDTO>().Build(contractAddresses), blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new() =>
+            CreateProcessor(
+                new[] {new EventLogProcessorHandler<TEventDTO>(action, criteria)}, 
+                minimumBlockConfirmations,
+                new FilterInputBuilder<TEventDTO>().Build(contractAddresses), 
+                blockProgressRepository, 
+                log, 
+                blockRangeRequestStrategy);
 
         public BlockchainProcessor CreateProcessor<TEventDTO>(
             Func<EventLog<TEventDTO>, Task> action,
             uint minimumBlockConfirmations,
             Func<EventLog<TEventDTO>, Task<bool>> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new() =>
-            CreateProcessor(new[] {new EventLogProcessorHandler<TEventDTO>(action, criteria)}, minimumBlockConfirmations,
-                new FilterInputBuilder<TEventDTO>().Build(), blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new() =>
+            CreateProcessor(
+                new[] {new EventLogProcessorHandler<TEventDTO>(action, criteria)}, 
+                minimumBlockConfirmations,
+                new FilterInputBuilder<TEventDTO>().Build(), 
+                blockProgressRepository, 
+                log, 
+                blockRangeRequestStrategy);
 
 
         public BlockchainProcessor CreateProcessorForContract<TEventDTO>(
@@ -75,9 +98,15 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations,
             Func<EventLog<TEventDTO>, Task<bool>> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new() =>
-            CreateProcessor(new[] {new EventLogProcessorHandler<TEventDTO>(action, criteria)}, minimumBlockConfirmations,
-                new FilterInputBuilder<TEventDTO>().Build(new[] {contractAddress}), blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new() =>
+            CreateProcessor(
+                new[] {new EventLogProcessorHandler<TEventDTO>(action, criteria)}, 
+                minimumBlockConfirmations,
+                new FilterInputBuilder<TEventDTO>().Build(new[] {contractAddress}), 
+                blockProgressRepository, 
+                log, 
+                blockRangeRequestStrategy);
 
         public BlockchainProcessor CreateProcessorForContracts<TEventDTO>(
             string[] contractAddresses,
@@ -85,18 +114,30 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations,
             Func<EventLog<TEventDTO>, Task<bool>> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new() =>
-            CreateProcessor(new[] {new EventLogProcessorHandler<TEventDTO>(action, criteria)}, minimumBlockConfirmations,
-                new FilterInputBuilder<TEventDTO>().Build(contractAddresses), blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new() =>
+            CreateProcessor(
+                new[] {new EventLogProcessorHandler<TEventDTO>(action, criteria)}, 
+                minimumBlockConfirmations,
+                new FilterInputBuilder<TEventDTO>().Build(contractAddresses), 
+                blockProgressRepository, 
+                log, 
+                blockRangeRequestStrategy);
 
         public BlockchainProcessor CreateProcessorForContracts<TEventDTO>(
             ProcessorHandler<FilterLog> logProcessor,
             string[] contractAddresses,
             uint minimumBlockConfirmations,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class =>
-            CreateProcessor(new[] {logProcessor}, minimumBlockConfirmations, new FilterInputBuilder<TEventDTO>().Build(contractAddresses),
-                blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class =>
+                CreateProcessor(
+                    new[] {logProcessor}, 
+                    minimumBlockConfirmations, 
+                    new FilterInputBuilder<TEventDTO>().Build(contractAddresses),
+                    blockProgressRepository, 
+                    log, 
+                    blockRangeRequestStrategy);
 
         public BlockchainProcessor CreateProcessorForContract(
 
@@ -105,8 +146,15 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations,
             Func<FilterLog, bool> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) => CreateProcessor(new[] {new ProcessorHandler<FilterLog>(action, criteria)}, minimumBlockConfirmations,
-            new NewFilterInput {Address = new[] {contractAddress}}, blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) =>
+                CreateProcessor(
+                    new[] {new ProcessorHandler<FilterLog>(action, criteria)}, 
+                    minimumBlockConfirmations,
+                    new NewFilterInput {Address = new[] {contractAddress}}, 
+                    blockProgressRepository, 
+                    log, 
+                    blockRangeRequestStrategy);
 
         public BlockchainProcessor CreateProcessorForContracts(
 
@@ -115,8 +163,15 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations,
             Func<FilterLog, bool> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) => CreateProcessor(new[] {new ProcessorHandler<FilterLog>(action, criteria)}, minimumBlockConfirmations,
-            new NewFilterInput {Address = contractAddresses}, blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) => 
+                CreateProcessor(
+                    new[] {new ProcessorHandler<FilterLog>(action, criteria)}, 
+                    minimumBlockConfirmations,
+                    new NewFilterInput {Address = contractAddresses}, 
+                    blockProgressRepository, 
+                    log, 
+                    blockRangeRequestStrategy);
 
 
         //sync action and criter
@@ -127,8 +182,15 @@ namespace Nethereum.BlockchainProcessing.Services
             Func<FilterLog, bool> criteria = null,
             NewFilterInput filter = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) => CreateProcessor(new[] {new ProcessorHandler<FilterLog>(action, criteria)}, minimumBlockConfirmations, filter,
-            blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) => 
+                CreateProcessor(
+                    new[] {new ProcessorHandler<FilterLog>(action, criteria)}, 
+                    minimumBlockConfirmations, 
+                    filter,
+                    blockProgressRepository, 
+                    log, 
+                    blockRangeRequestStrategy);
 
         //async action and criteria
         public BlockchainProcessor CreateProcessor(
@@ -138,8 +200,15 @@ namespace Nethereum.BlockchainProcessing.Services
             Func<FilterLog, Task<bool>> criteria = null,
             NewFilterInput filter = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) => CreateProcessor(new[] {new ProcessorHandler<FilterLog>(action, criteria)}, minimumBlockConfirmations, filter,
-            blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) => 
+                CreateProcessor(
+                    new[] {new ProcessorHandler<FilterLog>(action, criteria)}, 
+                    minimumBlockConfirmations, 
+                    filter,
+                    blockProgressRepository, 
+                    log, 
+                    blockRangeRequestStrategy);
 
         //single processor
         public BlockchainProcessor CreateProcessor(
@@ -148,7 +217,15 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations,
             NewFilterInput filter = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) => CreateProcessor(new[] {logProcessor}, minimumBlockConfirmations, filter, blockProgressRepository, log);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) => 
+                CreateProcessor(
+                    new[] {logProcessor}, 
+                    minimumBlockConfirmations, 
+                    filter, 
+                    blockProgressRepository, 
+                    log, 
+                    blockRangeRequestStrategy);
 
         //multi processor
         public BlockchainProcessor CreateProcessor(
@@ -157,9 +234,10 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations,
             NewFilterInput filter = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null)
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null)
         {
-            var orchestrator = new LogOrchestrator(_ethApiContractService, logProcessors, filter);
+            var orchestrator = new LogOrchestrator(_ethApiContractService, logProcessors, filter, blockRangeRequestStrategy);
 
             var progressRepository = blockProgressRepository ??
                                      new InMemoryBlockchainProgressRepository();

--- a/src/Nethereum.BlockchainProcessing/Services/IBlockchainBlockProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/IBlockchainBlockProcessingService.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Common.Logging;
+using Nethereum.BlockchainProcessing.BlockProcessing;
+using Nethereum.BlockchainProcessing.BlockStorage.Repositories;
+using Nethereum.BlockchainProcessing.ProgressRepositories;
+using Nethereum.RPC.Eth.Blocks;
+
+namespace Nethereum.BlockchainProcessing.Services
+{
+    public interface IBlockchainBlockProcessingService
+    {
+
+        BlockchainProcessor CreateBlockProcessor(
+            Action<BlockProcessingSteps> stepsConfiguration,
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
+            ILog log = null);
+
+        BlockchainProcessor CreateBlockProcessor(
+            IBlockProgressRepository blockProgressRepository,
+            Action<BlockProcessingSteps> stepsConfiguration,
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
+            ILog log = null);
+
+
+        BlockchainProcessor CreateBlockStorageProcessor(
+            IBlockchainStoreRepositoryFactory blockchainStorageFactory,
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
+            Action<BlockProcessingSteps> configureSteps = null,
+            ILog log = null);
+
+        BlockchainProcessor CreateBlockStorageProcessor(
+            IBlockchainStoreRepositoryFactory blockchainStorageFactory,
+            IBlockProgressRepository blockProgressRepository,
+            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
+            Action<BlockProcessingSteps> configureSteps = null,
+            ILog log = null);
+    }
+}

--- a/src/Nethereum.BlockchainProcessing/Services/IBlockchainLogProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/IBlockchainLogProcessingService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Common.Logging;
+using Nethereum.BlockchainProcessing.LogProcessing;
 using Nethereum.BlockchainProcessing.Processor;
 using Nethereum.BlockchainProcessing.ProgressRepositories;
 using Nethereum.Contracts;
@@ -17,7 +18,8 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Func<EventLog<TEventDTO>, bool> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new();
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new();
 
         BlockchainProcessor CreateProcessorForContract<TEventDTO>(
             string contractAddress,
@@ -25,7 +27,8 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Func<EventLog<TEventDTO>, bool> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new();
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new();
 
         BlockchainProcessor CreateProcessorForContracts<TEventDTO>(
             string[] contractAddresses,
@@ -33,14 +36,16 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Func<EventLog<TEventDTO>, bool> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new();
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new();
 
         BlockchainProcessor CreateProcessor<TEventDTO>(
             Func<EventLog<TEventDTO>, Task> action,
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Func<EventLog<TEventDTO>, Task<bool>> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new();
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new();
 
         BlockchainProcessor CreateProcessorForContract<TEventDTO>(
             string contractAddress,
@@ -48,7 +53,8 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Func<EventLog<TEventDTO>, Task<bool>> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new();
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new();
 
         BlockchainProcessor CreateProcessorForContracts<TEventDTO>(
             string[] contractAddresses,
@@ -56,14 +62,16 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Func<EventLog<TEventDTO>, Task<bool>> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class, new();
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class, new();
 
         BlockchainProcessor CreateProcessorForContracts<TEventDTO>(
             ProcessorHandler<FilterLog> logProcessor,
             string[] contractAddresses,
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null) where TEventDTO : class;
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null) where TEventDTO : class;
 
         BlockchainProcessor CreateProcessorForContract(
 
@@ -72,7 +80,8 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Func<FilterLog, bool> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null);
 
         BlockchainProcessor CreateProcessorForContracts(
 
@@ -81,7 +90,8 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             Func<FilterLog, bool> criteria = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null);
 
         BlockchainProcessor CreateProcessor(
 
@@ -90,7 +100,8 @@ namespace Nethereum.BlockchainProcessing.Services
             Func<FilterLog, bool> criteria = null,
             NewFilterInput filter = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null);
 
         BlockchainProcessor CreateProcessor(
 
@@ -99,7 +110,8 @@ namespace Nethereum.BlockchainProcessing.Services
             Func<FilterLog, Task<bool>> criteria = null,
             NewFilterInput filter = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null);
 
         BlockchainProcessor CreateProcessor(
 
@@ -107,7 +119,8 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             NewFilterInput filter = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null);
 
         BlockchainProcessor CreateProcessor(
 
@@ -115,6 +128,7 @@ namespace Nethereum.BlockchainProcessing.Services
             uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
             NewFilterInput filter = null,
             IBlockProgressRepository blockProgressRepository = null,
-            ILog log = null);
+            ILog log = null,
+            IBlockRangeRequestStrategy blockRangeRequestStrategy = null);
     }
 }

--- a/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
+++ b/src/Nethereum.BlockchainProcessing/Services/IBlockchainProcessingService.cs
@@ -12,33 +12,4 @@ namespace Nethereum.BlockchainProcessing.Services
         IBlockchainLogProcessingService Logs { get; }
         IBlockchainBlockProcessingService Blocks { get; }
     }
-
-    public interface IBlockchainBlockProcessingService
-    {
-
-        BlockchainProcessor CreateBlockProcessor(
-            Action<BlockProcessingSteps> stepsConfiguration,
-            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
-            ILog log = null);
-
-        BlockchainProcessor CreateBlockProcessor(
-            IBlockProgressRepository blockProgressRepository,
-            Action<BlockProcessingSteps> stepsConfiguration,
-            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
-            ILog log = null);
-
-
-        BlockchainProcessor CreateBlockStorageProcessor(
-            IBlockchainStoreRepositoryFactory blockchainStorageFactory,
-            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
-            Action<BlockProcessingSteps> configureSteps = null,
-            ILog log = null);
-
-        BlockchainProcessor CreateBlockStorageProcessor(
-            IBlockchainStoreRepositoryFactory blockchainStorageFactory,
-            IBlockProgressRepository blockProgressRepository,
-            uint minimumBlockConfirmations = LastConfirmedBlockNumberService.DEFAULT_BLOCK_CONFIRMATIONS,
-            Action<BlockProcessingSteps> configureSteps = null,
-            ILog log = null);
-    }
 }


### PR DESCRIPTION
For processing speed it's best to avoid repetitive log retrieval errors caused by an excessive block range which may return too many records for the client/node.  Although the processor has a retry algorithm that copes with these errors it can inevitably lead to slower performance.   

It is also possible that the user wants to limit the number of logs in memory at any one time during processing. 

This change allows the number of blocks per batch and retry weight to be set explicitly by providing an implementation of IBlockRangeRequestStrategy.  I have added this as an optional parameter to each method on the IBlockchainLogProcessingService interface.   Existing code will be backwards compatible (unless it is using reflection or mocks to create a log processor).  Optional parameters are consistent with the way other arguments are passed for these methods and seemed preferable to a whole set of new overloads.