### PR TITLE
Removing extension Block.TransactionCount.

### DIFF
--- a/src/Nethereum.BlockchainProcessing/BlockStorage/Entities/Mapping/BlockMapping.cs
+++ b/src/Nethereum.BlockchainProcessing/BlockStorage/Entities/Mapping/BlockMapping.cs
@@ -35,7 +35,18 @@ namespace Nethereum.BlockchainProcessing.BlockStorage.Entities.Mapping
             block.ParentHash = source.ParentHash ?? string.Empty;
             block.Miner = source.Miner ?? string.Empty;
             block.Nonce = source.Nonce;
-            block.TransactionCount = source.SupportsTransactionCount() ? source.TransactionCount() : 0;
+            block.TransactionCount = TransactionCount(source);
+        }
+
+        private static int TransactionCount(Nethereum.RPC.Eth.DTOs.Block block)
+        {
+            if (block is BlockWithTransactions b)
+                return b.Transactions?.Length ?? 0;
+
+            if (block is BlockWithTransactionHashes bh)
+                return bh.TransactionHashes?.Length ?? 0;
+
+            return 0;
         }
     }
 }

--- a/src/Nethereum.RPC.UnitTests/ExtensionTests.cs
+++ b/src/Nethereum.RPC.UnitTests/ExtensionTests.cs
@@ -47,28 +47,6 @@ namespace Nethereum.RPC.UnitTests
             Assert.Equal(blockWithTransactionHashes.TransactionHashes.Length, blockWithTransactionHashes.TransactionCount());
         }
 
-        [Fact]
-        public void Block_TransactionCount_Returns_0_Or_Throws_Depending_On_Flag()
-        {
-            var block = new Block();
-            Assert.Equal(0, block.TransactionCount(throwWhenNotSupported: false));
-
-            var ex = Assert.Throws<ArgumentException>(() => block.TransactionCount(throwWhenNotSupported: true));
-            const string EXPECTED_EXCEPTION_MESSAGE = "TransactionCount error.  Block does not support returning a transaction count.";
-            Assert.Equal(EXPECTED_EXCEPTION_MESSAGE, ex.Message);
-
-            //ensure the default is to throw if not supported
-            Assert.Throws<ArgumentException>(() => block.TransactionCount());
-        }
-
-        [Fact]
-        public void Block_Supports_Transaction_Count()
-        {
-            Assert.True(new BlockWithTransactionHashes().SupportsTransactionCount());
-            Assert.True(new BlockWithTransactions().SupportsTransactionCount());
-            Assert.False(new Block().SupportsTransactionCount());
-        }
-
         [Theory]
         [InlineData(Address1)]
         public void Transaction_IsToAnEmptyAddress_When_Address_Is_Not_Empty_Returns_False(string address)

--- a/src/Nethereum.RPC/Eth/DTOs/BlockExtensions.cs
+++ b/src/Nethereum.RPC/Eth/DTOs/BlockExtensions.cs
@@ -4,35 +4,14 @@ namespace Nethereum.RPC.Eth.DTOs
 {
     public static class BlockExtensions
     {
-        /// <summary>
-        /// If the Block type matches BlockWithTransactions or BlockWithTransactionHashes it returns the count (see SupportsTransactionCount).
-        /// </summary>
-        /// <param name="block">the block</param>
-        /// <param name="throwWhenNotSupported">throw an exception when the type does not support a transaction count</param>
-        /// <returns></returns>
-        public static int TransactionCount(this Block block, bool throwWhenNotSupported = true)
+        public static int TransactionCount(this BlockWithTransactions block)
         {
-            if (block is BlockWithTransactions b)
-                return b.Transactions?.Length ?? 0;
-
-            if (block is BlockWithTransactionHashes bh)
-                return bh.TransactionHashes?.Length ?? 0;
-
-            if(throwWhenNotSupported)
-                throw new ArgumentException($"TransactionCount error.  {block.GetType().Name} does not support returning a transaction count.");
-
-            return 0;
+            return block.Transactions?.Length ?? 0;
         }
 
-        public static bool SupportsTransactionCount<BlockType>(this BlockType block) where BlockType : Block
+        public static int TransactionCount(this BlockWithTransactionHashes block)
         {
-            if (block is BlockWithTransactions)
-                return true;
-
-            if (block is BlockWithTransactionHashes)
-                return true;
-
-            return false;
+            return block.TransactionHashes?.Length ?? 0;
         }
     }
 }


### PR DESCRIPTION
The extension method Block.TransactionCount was primarily added for Blockchain storage.  In storage a block repository could be given different sub types of block and would need to infer the type and get the transaction count.  

However this same extension appears for any Nethereum user.  If you only have a Block (not a BlockWithTransactions or BlockWithTransactionHashes) this method returns 0.  This is misleading.  I have added an option to throw an exception if the type of Block does not support the count.  The default is now to throw if it is not supported.   In that sense it is a breaking change but it seems right to correct that before it is too widely adopted.

I was tempted to remove this method completely - but some adapters in the storage repos depend on it and there is a small chance other developers have started using it.