### PR TITLE
StreamingWebSocketClient SendRequestAsync Handle null socket (1 of 4)

### DIFF
--- a/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
@@ -290,6 +290,8 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
 
         public async Task SendRequestAsync(RpcRequestMessage request, IRpcStreamingResponseHandler requestResponseHandler, string route = null )
         {
+            if (_clientWebSocket == null) throw new InvalidOperationException("Websocket is null.  Ensure that StartAsync has been called to create the websocket.");
+
             var logger = new RpcLogger(_log);
             
             try

--- a/src/Nethereum.RPC.IntegrationTests/Nethereum.RPC.IntegrationTests.csproj
+++ b/src/Nethereum.RPC.IntegrationTests/Nethereum.RPC.IntegrationTests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta4-build3742" />

--- a/src/Nethereum.RPC.IntegrationTests/Testers/Streaming/StreamingWebSocketClientTest.cs
+++ b/src/Nethereum.RPC.IntegrationTests/Testers/Streaming/StreamingWebSocketClientTest.cs
@@ -1,0 +1,29 @@
+﻿using Moq;
+using Nethereum.JsonRpc.Client.RpcMessages;
+using Nethereum.JsonRpc.Client.Streaming;
+using Nethereum.JsonRpc.WebSocketStreamingClient;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nethereum.RPC.Tests.Testers.Streaming
+{
+    public class StreamingWebSocketClientTest
+    {
+        /// <summary>
+        /// Ensures that there is error handling for the situation where SendAsync is called but the websocket is null
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task WhenWebSocketIsNull_SendAsync_ThrowsExpectedException()
+        {
+            var client = new StreamingWebSocketClient("");
+
+            var rpcRequestMessage = new RpcRequestMessage("", "");
+            var mockResponseHandler = new Mock<IRpcStreamingResponseHandler>();
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendRequestAsync(rpcRequestMessage, mockResponseHandler.Object));
+            Assert.Equal("Websocket is null.  Ensure that StartAsync has been called to create the websocket.", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
When using a subscription - if you did not call StartAsync on the webclient before calling SubscribeAsync on the subscription a null reference exception would occur within the call stack.  This is because the underlying websocket was not yet initialised.  It is necessary to call StartAsync first but it is sensible to guard against the scenario where it hasn't been and provide a helpful and meaningful error message.