### PR TITLE
Streaming Web Socket Connection Handling Improvements To Prevent Hanging (2 of 4)

### DIFF
--- a/src/Nethereum.JsonRpc.WebSocketClient/ClientWebSocketExtensions.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/ClientWebSocketExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.WebSockets;
+
+namespace Nethereum.JsonRpc.WebSocketStreamingClient
+{
+    public static class ClientWebSocketExtensions
+    {
+        public static bool IsNullOrNotOpen(this ClientWebSocket clientWebSocket)
+        {
+            return clientWebSocket?.State != WebSocketState.Open;
+        }
+
+        public static bool IsNotNullAndOpen(this ClientWebSocket clientWebSocket)
+        {
+            return clientWebSocket?.State == WebSocketState.Open;
+        }
+    }
+}

--- a/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
@@ -290,6 +290,8 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
 
         public async Task SendRequestAsync(RpcRequestMessage request, IRpcStreamingResponseHandler requestResponseHandler, string route = null )
         {
+            if (_clientWebSocket == null) throw new InvalidOperationException("Websocket is null.  Ensure that StartAsync has been called to create the websocket.");
+
             var logger = new RpcLogger(_log);
             
             try

--- a/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
@@ -29,7 +29,7 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
         private readonly string _path;
         public static int ForceCompleteReadTotalMilliseconds { get; set; } = 100000;
 
-        private ConcurrentDictionary<string, IRpcStreamingResponseHandler> _requests = new ConcurrentDictionary<string, IRpcStreamingResponseHandler>();
+        private readonly ConcurrentDictionary<string, IRpcStreamingResponseHandler> _requests = new ConcurrentDictionary<string, IRpcStreamingResponseHandler>();
 
         private Task _listener;
         private CancellationTokenSource _cancellationTokenSource;

--- a/src/Nethereum.RPC.IntegrationTests/Nethereum.RPC.IntegrationTests.csproj
+++ b/src/Nethereum.RPC.IntegrationTests/Nethereum.RPC.IntegrationTests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta4-build3742" />

--- a/src/Nethereum.RPC.IntegrationTests/Testers/Streaming/StreamingWebSocketClientTest.cs
+++ b/src/Nethereum.RPC.IntegrationTests/Testers/Streaming/StreamingWebSocketClientTest.cs
@@ -1,0 +1,29 @@
+﻿using Moq;
+using Nethereum.JsonRpc.Client.RpcMessages;
+using Nethereum.JsonRpc.Client.Streaming;
+using Nethereum.JsonRpc.WebSocketStreamingClient;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nethereum.RPC.Tests.Testers.Streaming
+{
+    public class StreamingWebSocketClientTest
+    {
+        /// <summary>
+        /// Ensures that there is error handling for the situation where SendAsync is called but the websocket is null
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task WhenWebSocketIsNull_SendAsync_ThrowsExpectedException()
+        {
+            var client = new StreamingWebSocketClient("");
+
+            var rpcRequestMessage = new RpcRequestMessage("", "");
+            var mockResponseHandler = new Mock<IRpcStreamingResponseHandler>();
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendRequestAsync(rpcRequestMessage, mockResponseHandler.Object));
+            Assert.Equal("Websocket is null.  Ensure that StartAsync has been called to create the websocket.", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
Whilst unit testing the subscriptions I experienced regular but random hanging.  Even when only running one test at a time the test would hang randomly.  

I found a few causes for this.  

+ The disposal order needed changing to ensure the HandleIncomingMessagesAsync loop was stopped before the connection was disposed. 
+ The new "read only" flag on the "_requests" variable made the biggest difference in preventing hanging.
+ A few null websocket guards were required in methods involved in the HandleIncomingMessagesAsync  loop.

As there were multiple connection "not null and open" checks I added a simple extension method for this for readability and reuse.

Reworked subscription tests are coming in a forthcoming PR.