### PR TITLE
New BigDecimal.ToString overload, that accepts format string + CultureInfo

### DIFF
--- a/src/Nethereum.Util.UnitTests/FormattingTests.cs
+++ b/src/Nethereum.Util.UnitTests/FormattingTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+namespace Nethereum.Util.UnitTests {
+    public class FormattingTests {
+        [Theory]
+        [InlineData("1", "c", "en-US")]
+        [InlineData("1.1", "c", "en-US")]
+        [InlineData("-1.1", "c", "en-US")]
+        [InlineData("-100000.1", "c", "en-US")]
+        [InlineData("-0.0000000000000000000000001", "c", "en-US")]
+        [InlineData("0.0000000000000000000000001", "c", "en-US")]
+        // should round up
+        [InlineData("0.5", "c0", "en-US")]
+        [InlineData("0.51", "c0", "en-US")]
+        [InlineData("-0.5", "c0", "en-US")]
+        // should round down
+        [InlineData("-0.51", "c0", "en-US")]
+        [InlineData("-0.4", "c0", "en-US")]
+        [InlineData("0.4", "c0", "en-US")]
+        public void ShouldFormatBigDecimalCurrency(string numberText, string format, string localeName) {
+            decimal number = decimal.Parse(numberText, CultureInfo.InvariantCulture);
+            BigDecimal bigNumber = number;
+            var cultureInfo = CultureInfo.GetCultureInfo(localeName);
+            string expected = number.ToString(format, cultureInfo);
+            string result = bigNumber.ToString(format, cultureInfo);
+            Assert.Equal(expected, result);
+        }
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("en-GB")]
+        [InlineData("he-IL")]
+        public void ShouldFormatBigDecimalCurrencyWithWildExponent(string localeName) {
+            var cultureInfo = CultureInfo.GetCultureInfo(localeName);
+
+            foreach (int mantissa in new[] {1, 100})
+            foreach (int exponent in new[] {5, -5}) {
+                var bigNumber = new BigDecimal(mantissa: mantissa, exponent: exponent);
+                decimal number = (decimal)bigNumber;
+                string expected = number.ToString("c", cultureInfo);
+                string result = bigNumber.ToString("c", cultureInfo);
+                Assert.Equal(expected, result);
+            }
+        }
+    }
+}

--- a/src/Nethereum.Util/BigDecimal.Formatter.cs
+++ b/src/Nethereum.Util/BigDecimal.Formatter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Nethereum.Util {
+    internal static class BigDecimalFormatter {
+        public static string ToCurrencyString(this BigDecimal value, int maxDigits, NumberFormatInfo format) {
+            value.Normalize();
+
+            if (maxDigits < 0)
+                maxDigits = format.CurrencyDecimalDigits;
+
+            BigDecimal rounded = value.Round(significantDigits: maxDigits);
+            var digits = rounded.GetDigits(out int exponent);
+            var result = new StringBuilder();
+            NumberFormatting.FormatCurrency(result,
+                rounded.Mantissa < 0, digits, exponent,
+                maxDigits: maxDigits, info: format);
+            return result.ToString();
+        }
+
+        internal static IList<byte> GetDigits(this BigDecimal value, out int exponent) {
+            var nonNegativeMantissa = value.Mantissa < 0 ? -value.Mantissa : value.Mantissa;
+            var result = new List<byte>();
+            while (nonNegativeMantissa > 0) {
+                result.Add((byte)(nonNegativeMantissa % 10 + '0'));
+                nonNegativeMantissa /= 10;
+            }
+            result.Reverse();
+            exponent = value.Exponent;
+            return result;
+        }
+    }
+}

--- a/src/Nethereum.Util/NumberFormatting.cs
+++ b/src/Nethereum.Util/NumberFormatting.cs
@@ -1,0 +1,198 @@
+﻿namespace Nethereum.Util {
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Runtime.InteropServices;
+    using System.Text;
+
+    internal static class NumberFormatting {
+        private static readonly string[] s_posCurrencyFormats =
+        {
+            "$#", "#$", "$ #", "# $"
+        };
+
+        private static readonly string[] s_negCurrencyFormats =
+        {
+            "($#)", "-$#", "$-#", "$#-",
+            "(#$)", "-#$", "#-$", "#$-",
+            "-# $", "-$ #", "# $-", "$ #-",
+            "$ -#", "#- $", "($ #)", "(# $)"
+        };
+
+        internal static char ParseFormatSpecifier(string format, out int digits) {
+            char c = default;
+            if (format.Length > 0) {
+                // If the format begins with a symbol, see if it's a standard format
+                // with or without a specified number of digits.
+                c = format[0];
+                if ((uint)(c - 'A') <= 'Z' - 'A' ||
+                    (uint)(c - 'a') <= 'z' - 'a') {
+                    // Fast path for sole symbol, e.g. "D"
+                    if (format.Length == 1) {
+                        digits = -1;
+                        return c;
+                    }
+
+                    if (format.Length == 2) {
+                        // Fast path for symbol and single digit, e.g. "X4"
+                        int d = format[1] - '0';
+                        if ((uint)d < 10) {
+                            digits = d;
+                            return c;
+                        }
+                    } else if (format.Length == 3) {
+                        // Fast path for symbol and double digit, e.g. "F12"
+                        int d1 = format[1] - '0', d2 = format[2] - '0';
+                        if ((uint)d1 < 10 && (uint)d2 < 10) {
+                            digits = d1 * 10 + d2;
+                            return c;
+                        }
+                    }
+
+                    // Fallback for symbol and any length digits.  The digits value must be >= 0 && <= 99,
+                    // but it can begin with any number of 0s, and thus we may need to check more than two
+                    // digits.  Further, for compat, we need to stop when we hit a null char.
+                    int n = 0;
+                    int i = 1;
+                    while (i < format.Length && (((uint)format[i] - '0') < 10) && n < 10) {
+                        n = (n * 10) + format[i++] - '0';
+                    }
+
+                    // If we're at the end of the digits rather than having stopped because we hit something
+                    // other than a digit or overflowed, return the standard format info.
+                    if (i == format.Length || format[i] == '\0') {
+                        digits = n;
+                        return c;
+                    }
+                }
+            }
+
+            // Default empty format to be "G"; custom format is signified with '\0'.
+            digits = -1;
+            return format.Length == 0 || c == '\0' ? // For compat, treat '\0' as the end of the specifier, even if the specifier extends beyond it.
+                'G' :
+                '\0';
+        }
+
+        internal static void FormatCurrency(StringBuilder result,
+            bool isNegative, IList<byte> digits, int exponent,
+            int maxDigits, NumberFormatInfo info) {
+            string fmt = isNegative ?
+                s_negCurrencyFormats[info.CurrencyNegativePattern] :
+                s_posCurrencyFormats[info.CurrencyPositivePattern];
+
+            foreach (char ch in fmt) {
+                switch (ch) {
+                case '#':
+                    FormatFixed(result, digits, exponent,
+                        maxFractionalDigits: maxDigits,
+                        info.CurrencyGroupSizes,
+                        decimalSeparator: info.CurrencyDecimalSeparator,
+                        groupSeparator: info.CurrencyGroupSeparator);
+                    break;
+                case '-':
+                    result.Append(info.NegativeSign);
+                    break;
+                case '$':
+                    result.Append(info.CurrencySymbol);
+                    break;
+                default:
+                    result.Append(ch);
+                    break;
+                }
+            }
+        }
+
+        internal static void FormatFixed(StringBuilder sb, IList<byte> digits, int exponent,
+            int maxFractionalDigits,
+            int[] groupDigits, string decimalSeparator, string groupSeparator) {
+            int digPos = digits.Count+exponent;
+            int digitIndex = 0;
+
+            if (digPos > 0) {
+                if (groupDigits != null) {
+                    Debug.Assert(groupSeparator != null, "Must be null when groupDigits != null");
+                    int groupSizeIndex = 0;               // Index into the groupDigits array.
+                    int bufferSize = digPos;              // The length of the result buffer string.
+                    int groupSize = 0;                    // The current group size.
+
+                    // Find out the size of the string buffer for the result.
+                    if (groupDigits.Length != 0) // You can pass in 0 length arrays
+                    {
+                        int groupSizeCount = groupDigits[groupSizeIndex];   // The current total of group size.
+
+                        while (digPos > groupSizeCount) {
+                            groupSize = groupDigits[groupSizeIndex];
+                            if (groupSize == 0)
+                                break;
+
+                            bufferSize += groupSeparator.Length;
+                            if (groupSizeIndex < groupDigits.Length - 1)
+                                groupSizeIndex++;
+
+                            groupSizeCount += groupDigits[groupSizeIndex];
+                            if (groupSizeCount < 0 || bufferSize < 0)
+                                throw new ArgumentOutOfRangeException(); // If we overflow
+                        }
+
+                        groupSize = groupSizeCount == 0 ? 0 : groupDigits[0]; // If you passed in an array with one entry as 0, groupSizeCount == 0
+                    }
+
+                    groupSizeIndex = 0;
+                    int digitCount = 0;
+                    //int digLength = number.DigitsCount;
+                    int digLength = digits.Count;
+                    int digStart = (digPos < digLength) ? digPos : digLength;
+                    char[] spanPtr = new char[bufferSize];
+                    int p = bufferSize - 1;
+                    for (int i = digPos - 1; i >= 0; i--) {
+                        spanPtr[p--] = (i < digStart) ? (char)(digits[digitIndex + i]) : '0';
+
+                        if (groupSize > 0) {
+                            digitCount++;
+                            if ((digitCount == groupSize) && (i != 0)) {
+                                for (int j = groupSeparator.Length - 1; j >= 0; j--)
+                                    spanPtr[p--] = groupSeparator[j];
+
+                                if (groupSizeIndex < groupDigits.Length - 1) {
+                                    groupSizeIndex++;
+                                    groupSize = groupDigits[groupSizeIndex];
+                                }
+                                digitCount = 0;
+                            }
+                        }
+                    }
+
+                    sb.Append(spanPtr);
+
+                    Debug.Assert(p >= -1, "Underflow");
+                    digitIndex += digStart;
+                } else {
+                    do {
+                        sb.Append(digitIndex < digits.Count ? (char)digits[digitIndex++] : '0');
+                    }
+                    while (--digPos > 0);
+                }
+            } else {
+                sb.Append('0');
+            }
+
+            if (maxFractionalDigits > 0) {
+                Debug.Assert(decimalSeparator != null);
+                sb.Append(decimalSeparator);
+                if ((digPos < 0) && (maxFractionalDigits > 0)) {
+                    int zeroes = Math.Min(-digPos, maxFractionalDigits);
+                    sb.Append('0', zeroes);
+                    digPos += zeroes;
+                    maxFractionalDigits -= zeroes;
+                }
+
+                while (maxFractionalDigits > 0) {
+                    sb.Append((digitIndex < digits.Count) ? (char)digits[digitIndex++] : '0');
+                    maxFractionalDigits--;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Code ported (with quite a bit of adaptations to support .NET Standard 1.x) from https://github.com/dotnet/corefx/blob/bd5ff7a1f86be8b44697d2e6ab93be1510158e90/src/Common/src/CoreLib/System/Number.Formatting.cs

Summary of changes:
- new class `NumberFormatter`, that has methods helping to format numbers provided a list of digits, and a decimal dot position
- new class `BigDecimalFormatter`, that implements currency formatter for `BigDecimal`
- added `BigDecimal.Round`, that rounds to a specified number of significant digits, as it was needed by formatters
- formatting tests (unfortunately, I don't have code coverage setup, so can't check coverage %)