### PR TITLE
Fixed BigDecimal currency rounding for -0.5 (was: 0, now -1)

### DIFF
--- a/src/Nethereum.Util.UnitTests/BigDecimalTests.cs
+++ b/src/Nethereum.Util.UnitTests/BigDecimalTests.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿using System;
+using System.Globalization;
+
+using Xunit;
 
 namespace Nethereum.Util.UnitTests
 {
@@ -82,6 +85,25 @@ namespace Nethereum.Util.UnitTests
         public void ShouldCastToInt()
         {
             Assert.Equal(200, (int) (BigDecimal) 200.002m);
+        }
+
+        [Theory]
+        [InlineData("0.5")]
+        [InlineData("-0.5")]
+        [InlineData("0.51")]
+        [InlineData("-0.51")]
+        [InlineData("1")]
+        [InlineData("0")]
+        [InlineData("-1")]
+        public void ShouldRoundCorrectly(string value)
+        {
+            var big = BigDecimal.Parse(value);
+            decimal regular = decimal.Parse(value, CultureInfo.InvariantCulture);
+
+            decimal roundedRegular = Math.Round(regular, MidpointRounding.AwayFromZero);
+            var roundedBig = big.RoundAwayFromZero(significantDigits: 0);
+
+            Assert.Equal(expected: (BigDecimal)roundedRegular, roundedBig);
         }
     }
 }

--- a/src/Nethereum.Util/BigDecimal.Formatter.cs
+++ b/src/Nethereum.Util/BigDecimal.Formatter.cs
@@ -11,7 +11,7 @@ namespace Nethereum.Util {
             if (maxDigits < 0)
                 maxDigits = format.CurrencyDecimalDigits;
 
-            BigDecimal rounded = value.Round(significantDigits: maxDigits);
+            BigDecimal rounded = value.RoundAwayFromZero(significantDigits: maxDigits);
             var digits = rounded.GetDigits(out int exponent);
             var result = new StringBuilder();
             NumberFormatting.FormatCurrency(result,

--- a/src/Nethereum.Util/BigDecimal.cs
+++ b/src/Nethereum.Util/BigDecimal.cs
@@ -124,30 +124,26 @@ namespace Nethereum.Util
 
         /// <summary>
         /// Rounds the number to the specified amount of significant digits.
+        /// Midpoints (like 0.5 or -0.5) are rounded away from 0 (e.g. to 1 and -1 respectively).
         /// </summary>
-        internal BigDecimal Round(int significantDigits) {
+        public BigDecimal RoundAwayFromZero(int significantDigits) {
             if (significantDigits < 0 || significantDigits > 2_000_000_000)
                 throw new ArgumentOutOfRangeException(paramName: nameof(significantDigits));
 
             if (Exponent >= -significantDigits) return this;
 
-            var shortened = this;
+            bool negative = this.Mantissa < 0;
+            var shortened = negative ? -this : this;
             shortened.Normalize();
-            bool negativeCarry = false;
 
             while (shortened.Exponent < -significantDigits) {
                 var rem = shortened.Mantissa % 10;
                 shortened.Mantissa /= 10;
-                shortened.Mantissa +=
-                    rem >= 5 ? +1
-                    : rem >= -4 ? 0
-                    : rem < -5 ? -1
-                    : negativeCarry ? -1: 0;
-                negativeCarry = rem < 0;
+                shortened.Mantissa += rem >= 5 ? +1 : 0;
                 shortened.Exponent++;
             }
 
-            return shortened;
+            return negative ? -shortened : shortened;
         }
 
         /// <summary>

--- a/src/Nethereum.Util/BigDecimal.cs
+++ b/src/Nethereum.Util/BigDecimal.cs
@@ -137,8 +137,7 @@ namespace Nethereum.Util
             shortened.Normalize();
 
             while (shortened.Exponent < -significantDigits) {
-                var rem = shortened.Mantissa % 10;
-                shortened.Mantissa /= 10;
+                shortened.Mantissa = BigInteger.DivRem(shortened.Mantissa, 10, out var rem);
                 shortened.Mantissa += rem >= 5 ? +1 : 0;
                 shortened.Exponent++;
             }


### PR DESCRIPTION
Fixed an error in #596: rounding test for `-0.5` was failing, as currencies are expected to be rounded away from 0.

Added rounding tests.