### PR TITLE
RPC Memory leak fix: Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs

### DIFF
--- a/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
@@ -128,14 +128,12 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
 
         private async Task ConnectWebSocketAsync()
         {
-            CancellationTokenSource tokenSource = null;
             try
             {
-                tokenSource = new CancellationTokenSource(ConnectionTimeout);
                 if (_clientWebSocket == null || _clientWebSocket.State != WebSocketState.Open)
                 {
                     _clientWebSocket = new ClientWebSocket();
-                    await _clientWebSocket.ConnectAsync(new Uri(_path), tokenSource.Token).ConfigureAwait(false);
+                    await _clientWebSocket.ConnectAsync(new Uri(_path), new CancellationTokenSource(ConnectionTimeout).Token).ConfigureAwait(false);
 
                 }
             }
@@ -149,11 +147,6 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
             {
                 HandleError(ex);
                 throw;
-            }
-            finally
-            {
-                tokenSource?.Dispose();
-                tokenSource = null;
             }
         }
 
@@ -169,25 +162,16 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
 
         public async Task<int> ReceiveBufferedResponseAsync(ClientWebSocket client, byte[] buffer)
         {
-            CancellationTokenSource timeoutTokenSource = null;
-            CancellationTokenSource tokenSource = null;
-
             try
             {
-                timeoutTokenSource = new CancellationTokenSource(ForceCompleteReadTotalMilliseconds);
-                tokenSource = CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.Token, timeoutTokenSource.Token);
+                var timeoutToken = new CancellationTokenSource(ForceCompleteReadTotalMilliseconds).Token;
+                var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.Token, timeoutToken);
 
                 if (client == null) return 0;
                 var segmentBuffer = new ArraySegment<byte>(buffer);
                 var result = await client
                     .ReceiveAsync(segmentBuffer, tokenSource.Token)
                     .ConfigureAwait(false);
-
-                timeoutTokenSource?.Dispose();
-                timeoutTokenSource = null;
-                tokenSource?.Dispose();
-                tokenSource = null;
-
                 return result.Count;
             }
             catch (TaskCanceledException ex)
@@ -195,11 +179,6 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
                 var exception = new RpcClientTimeoutException($"Rpc timeout after {ConnectionTimeout.TotalMilliseconds} milliseconds", ex);
                 HandleError(exception);
                 throw exception;
-            }
-            finally
-            {
-                timeoutTokenSource?.Dispose();
-                tokenSource?.Dispose();
             }
         }
 
@@ -314,14 +293,14 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
             if (_clientWebSocket == null) throw new InvalidOperationException("Websocket is null.  Ensure that StartAsync has been called to create the websocket.");
 
             var logger = new RpcLogger(_log);
-            CancellationTokenSource timeoutCancellationTokenSource = null;
+
             try
             {
                 await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
                 var rpcRequestJson = JsonConvert.SerializeObject(request, JsonSerializerSettings);
                 var requestBytes = new ArraySegment<byte>(Encoding.UTF8.GetBytes(rpcRequestJson));
                 logger.LogRequest(rpcRequestJson);
-                timeoutCancellationTokenSource = new CancellationTokenSource();
+                var timeoutCancellationTokenSource = new CancellationTokenSource();
                 timeoutCancellationTokenSource.CancelAfter(ConnectionTimeout);
 
                 var webSocket = _clientWebSocket;
@@ -337,7 +316,6 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
             }
             finally
             {
-                timeoutCancellationTokenSource?.Dispose();
                 _semaphoreSlim.Release();
             }
         }
@@ -351,14 +329,12 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
         {
             IsStarted = false;
 
-            CancellationTokenSource tokenSource = null;
             try
             {
                 if (_clientWebSocket != null)
                 {
-                    tokenSource = new CancellationTokenSource(ConnectionTimeout);
                     await _clientWebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "",
-                        tokenSource.Token);
+                        new CancellationTokenSource(ConnectionTimeout).Token);
                 }
 
                 _clientWebSocket?.Dispose();
@@ -370,14 +346,13 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
             }
             finally
             {
-                tokenSource?.Dispose();
-                tokenSource = null;
                 _clientWebSocket = null;
             }
 
             try
             {
                 _cancellationTokenSource?.Cancel();
+                _cancellationTokenSource?.Dispose();
             }
             catch
             {
@@ -385,7 +360,6 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
             }
             finally
             {
-                _cancellationTokenSource?.Dispose();
                 _cancellationTokenSource = null;
             }
 

--- a/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
@@ -90,7 +90,7 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
 
                 if (_requests.TryRemove(response.Id.ToString(), out handler))
                 {
-                     handler.HandleResponse(response);
+                    handler.HandleResponse(response);
                 }
             }
         }
@@ -109,7 +109,7 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
             }
 
             _cancellationTokenSource = new CancellationTokenSource();
- 
+
             _listener = Task.Factory.StartNew(async () =>
             {
                 await HandleIncomingMessagesAsync();
@@ -145,7 +145,7 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
                 HandleError(rpcException);
                 throw rpcException;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 HandleError(ex);
                 throw;
@@ -159,10 +159,10 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
 
         private void HandleError(Exception exception)
         {
-            Error?.Invoke(this,exception);
+            Error?.Invoke(this, exception);
             foreach (var rpcStreamingResponseHandler in _requests)
             {
-                rpcStreamingResponseHandler.Value.HandleClientError(exception);    
+                rpcStreamingResponseHandler.Value.HandleClientError(exception);
             }
             CloseDisposeAndClearRequestsAsync().Wait();
         }
@@ -224,7 +224,7 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
                     var buffer = new byte[readBufferSize];
                     var bytesRead = await ReceiveBufferedResponseAsync(client, buffer).ConfigureAwait(false);
                     if (bytesRead == 0) completedNextMessage = true;
-                   
+
                     completedNextMessage = ProcessNextMessageBytes(buffer, memoryStream, bytesRead);
                 }
             }
@@ -232,7 +232,7 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
             return memoryStream;
         }
 
-        protected bool ProcessNextMessageBytes(byte[] buffer, MemoryStream memoryStream, int bytesRead=-1)
+        protected bool ProcessNextMessageBytes(byte[] buffer, MemoryStream memoryStream, int bytesRead = -1)
         {
             int currentIndex = 0;
             //bytesRead == -1 used to signal cached previous buffer
@@ -244,9 +244,9 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
                 bufferToRead = bytesRead;
             }
 
-            while(currentIndex < bufferToRead)
+            while (currentIndex < bufferToRead)
             {
-                if(buffer[currentIndex] == 10)
+                if (buffer[currentIndex] == 10)
                 {
                     if (currentIndex + 1 < bufferToRead) // bytes remaining
                     {
@@ -274,7 +274,7 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
 
             return false;
         }
-            
+
 
         private async Task HandleIncomingMessagesAsync()
         {
@@ -309,7 +309,7 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
             }
         }
 
-        public async Task SendRequestAsync(RpcRequestMessage request, IRpcStreamingResponseHandler requestResponseHandler, string route = null )
+        public async Task SendRequestAsync(RpcRequestMessage request, IRpcStreamingResponseHandler requestResponseHandler, string route = null)
         {
             if (_clientWebSocket == null) throw new InvalidOperationException("Websocket is null.  Ensure that StartAsync has been called to create the websocket.");
 
@@ -429,7 +429,7 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
             var reqMsg = new RpcRequestMessage(request.Id,
                                              request.Method,
                                              request.RawParameters);
-             await SendRequestAsync(reqMsg, requestResponseHandler, route).ConfigureAwait(false);
+            await SendRequestAsync(reqMsg, requestResponseHandler, route).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Fix dispose CancellationTokenSource for prevent memory leak.