### PR TITLE
RpcClient Connection fix

### DIFF
--- a/src/Nethereum.Contracts.IntegrationTests/SmartContracts/ErrorReasonTest.cs
+++ b/src/Nethereum.Contracts.IntegrationTests/SmartContracts/ErrorReasonTest.cs
@@ -58,7 +58,7 @@ namespace Nethereum.Contracts.IntegrationTests.SmartContracts
                     await contractHandler.QueryAsync<ThrowItFunction, bool>());
                 Assert.Equal("Smart contract error: An error message", error.Message);
             }
-            else // parity
+            else // parity throws Rpc exception : "VM execution error."
             {
                 var web3 = _ethereumClientIntegrationFixture.GetWeb3();
                 var errorThrowDeployment = new ErrorThrowDeployment();

--- a/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
+++ b/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
@@ -46,13 +46,13 @@ namespace Nethereum.JsonRpc.Client
             _httpClient = GetClient();
         }
 
-        protected override async Task<RpcResponseMessage> SendAsync(RpcRequestMessage request, string route = null)
+        protected override async Task<RpcResponseMessage> SendAsync(RpcRequestMessage rpcRequestMessage, string route = null)
         {
             var logger = new RpcLogger(_log);
             var cancellationTokenSource = new CancellationTokenSource();
             try
             {
-                var rpcRequestJson = JsonConvert.SerializeObject(request, _jsonSerializerSettings);
+                var rpcRequestJson = JsonConvert.SerializeObject(rpcRequestMessage, _jsonSerializerSettings);
                 var httpContent = new StringContent(rpcRequestJson, Encoding.UTF8, "application/json");
                 cancellationTokenSource.CancelAfter(ConnectionTimeout);
 

--- a/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
+++ b/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
@@ -144,9 +144,11 @@ namespace Nethereum.JsonRpc.Client
                 var httpClient = _httpClientHandler != null ? new HttpClient(_httpClientHandler) : new HttpClient();
                 httpClient.DefaultRequestHeaders.Authorization = _authHeaderValue;
                 httpClient.BaseAddress = _baseUrl;
-                httpClient.DefaultRequestHeaders.ConnectionClose = false;
-                ServicePointManager.FindServicePoint(_baseUrl).ConnectionLimit = 10000;
-                _httpClients.Add(_baseUrl.AbsoluteUri, httpClient);
+                httpClient.DefaultRequestHeaders.ConnectionClose = false; //keepAlive by default
+                var servicePoint = ServicePointManager.FindServicePoint(_baseUrl);
+                servicePoint.ConnectionLimit = 2000; // 2000 connections
+                servicePoint.ConnectionLeaseTimeout = 10000; //10 sec
+                _httpClients.Add(_baseUrl.AbsoluteUri, httpClient); //store for reuse
                 return httpClient;
             }
         }

--- a/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
+++ b/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
@@ -136,7 +136,7 @@ namespace Nethereum.JsonRpc.Client
         {
             lock (_lockObject)
             {
-                if (_httpClients[_baseUrl.AbsoluteUri] != null)
+                if (_httpClients.ContainsKey(_baseUrl.AbsoluteUri))
                 {
                     return _httpClients[_baseUrl.AbsoluteUri];
                 }

--- a/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
+++ b/src/Nethereum.JsonRpc.RpcClient/RpcClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -143,6 +144,8 @@ namespace Nethereum.JsonRpc.Client
                 var httpClient = _httpClientHandler != null ? new HttpClient(_httpClientHandler) : new HttpClient();
                 httpClient.DefaultRequestHeaders.Authorization = _authHeaderValue;
                 httpClient.BaseAddress = _baseUrl;
+                httpClient.DefaultRequestHeaders.ConnectionClose = false;
+                ServicePointManager.FindServicePoint(_baseUrl).ConnectionLimit = 10000;
                 _httpClients.Add(_baseUrl.AbsoluteUri, httpClient);
                 return httpClient;
             }


### PR DESCRIPTION
Under heavy load, the previously used solution eventually led to a situation where it was impossible to obtain a connection. Because HttpClient is designed to be reused within the lifetime of a process, added a dictionary of created instances of HttpClient relative to baseUrl. In addition, I enabled the settings of non-termination of connections (necessary for re-use) and made the limit of connections in the fields of the RpcClient class. The tests showed no problem with the inability to allocate the connection and confirmed the limited growth of open connections, indicating successful re-use.
