### PR TITLE
Update EncodedPack for AddressArrayType

### DIFF
--- a/src/Nethereum.ABI.UnitTests/ABIPackingTests.cs
+++ b/src/Nethereum.ABI.UnitTests/ABIPackingTests.cs
@@ -26,6 +26,17 @@ namespace Nethereum.ABI.UnitTests
                 soliditySha3.GetABIEncodedPacked(new ABIValue("address", "0x12890D2cce102216644c59daE5baed380d84830c"))
                     .ToHex(true).ConvertToEthereumChecksumAddress());
         }
+         
+        [Fact]
+        public virtual void ShouldEncodePackedArrayAddress()
+        {
+            var paramsEncoded = "0x0000000000000000000000007dd31bc2ffa37ab492a8d60f9c7170b78f12e1c50000000000000000000000000efa8015fcec7039feb656a4830aa6518bf46010";
+
+            var addreses = new string[] { "0x7Dd31bc2ffA37Ab492a8d60F9C7170B78f12E1c5", "0x0efa8015fcec7039feb656a4830aa6518bf46010" };
+            var abiEncode = new ABIEncode();
+            var result = abiEncode.GetABIEncodedPacked(new ABIValue("address[]", addreses)); 
+            Assert.Equal(paramsEncoded, result.ToHex(true));
+        }
 
         [Theory]
         [InlineData(42, "uint8", "2a")]

--- a/src/Nethereum.ABI.UnitTests/AbiEncodeTests.cs
+++ b/src/Nethereum.ABI.UnitTests/AbiEncodeTests.cs
@@ -40,18 +40,6 @@ namespace Nethereum.ABI.UnitTests
             Assert.Equal("0x" + paramsEncoded, result.ToHex(true));
         }
 
-
-        [Fact]
-        public virtual void ShouldEncodePackedArrayAddressType()
-        {
-            var paramsEncoded = "0x0000000000000000000000007dd31bc2ffa37ab492a8d60f9c7170b78f12e1c10000000000000000000000000efa8015fcec7039feb656a4830aa6518bf46011";
-
-            var addreses = new string[] { "0x7Dd31bc2ffA37Ab492a8d60F9C7170B78f12E1c1", "0x0efa8015fcec7039feb656a4830aa6518bf46011" };
-            var abiEncode = new ABIEncode();
-            var result = abiEncode.GetABIEncodedPacked(new ABIValue("address[]", addreses));
-            Assert.Equal(paramsEncoded, result.ToHex(true));
-        }
-
         public class TestParamsInput
         {
             [Parameter("string", 1)]

--- a/src/Nethereum.ABI.UnitTests/AbiEncodeTests.cs
+++ b/src/Nethereum.ABI.UnitTests/AbiEncodeTests.cs
@@ -39,6 +39,19 @@ namespace Nethereum.ABI.UnitTests
             var result = abiEncode.GetABIParamsEncoded(new TestParamsInput(){First = "hello", Second = 69, Third = "world"});
             Assert.Equal("0x" + paramsEncoded, result.ToHex(true));
         }
+
+
+        [Fact]
+        public virtual void ShouldEncodePackedArrayAddressType()
+        {
+            var paramsEncoded = "0x0000000000000000000000007dd31bc2ffa37ab492a8d60f9c7170b78f12e1c10000000000000000000000000efa8015fcec7039feb656a4830aa6518bf46011";
+
+            var addreses = new string[] { "0x7Dd31bc2ffA37Ab492a8d60F9C7170B78f12E1c1", "0x0efa8015fcec7039feb656a4830aa6518bf46011" };
+            var abiEncode = new ABIEncode();
+            var result = abiEncode.GetABIEncodedPacked(new ABIValue("address[]", addreses));
+            Assert.Equal(paramsEncoded, result.ToHex(true));
+        }
+
         public class TestParamsInput
         {
             [Parameter("string", 1)]

--- a/src/Nethereum.ABI/DynamicArrayType.cs
+++ b/src/Nethereum.ABI/DynamicArrayType.cs
@@ -8,7 +8,8 @@ namespace Nethereum.ABI
         public DynamicArrayType(string name) : base(name)
         {
             Decoder = new DynamicArrayTypeDecoder(ElementType);
-            Encoder = new DynamicArrayTypeEncoder(ElementType);
+            //check AddressType
+            Encoder = "address".Equals(ElementType.CanonicalName) ? new DynamicAddressArrayTypeEncoder(ElementType) : new DynamicAddressArrayTypeEncoder(ElementType);
         }
 
         public override string CanonicalName => ElementType.CanonicalName + "[]";

--- a/src/Nethereum.ABI/Encoders/DynamicArrayTypeEncoder.cs
+++ b/src/Nethereum.ABI/Encoders/DynamicArrayTypeEncoder.cs
@@ -51,4 +51,22 @@ namespace Nethereum.ABI.Encoders
             return ByteUtil.Merge(elems);
         }
     }
+
+    public class DynamicAddressArrayTypeEncoder : DynamicArrayTypeEncoder
+    {
+        readonly ABIType _elementType;
+
+        public DynamicAddressArrayTypeEncoder(ABIType elementType) : base(elementType)
+        {
+            _elementType = elementType;
+        }
+
+        public override byte[] EncodeListPacked(IList l)
+        {
+            var elems = new byte[l.Count][];
+            for (var i = 0; i < l.Count; i++)
+                elems[i] = _elementType.Encode(l[i]);
+            return ByteUtil.Merge(elems);
+        }
+    }
 }


### PR DESCRIPTION
EncodedPack for array address 

On solidity:
![image](https://user-images.githubusercontent.com/25890459/72049012-a92c1600-32f0-11ea-8263-0c92fae347fd.png)

NEthereum (lastest version) :
![tempsnip](https://user-images.githubusercontent.com/25890459/72050398-9a932e00-32f3-11ea-80a8-105443444780.png)


I updated ArrayAddressTypeEncoder.
Thanks
