### PR TITLE
Update ABIDeserialiser.cs - For Solidity >= 0.6.0

### DIFF
--- a/src/Nethereum.ABI/JsonDeserialisation/ABIDeserialiser.cs
+++ b/src/Nethereum.ABI/JsonDeserialisation/ABIDeserialiser.cs
@@ -67,7 +67,19 @@ namespace Nethereum.ABI.JsonDeserialisation
 
         public FunctionABI BuildFunction(IDictionary<string, object> function)
         {
-            var functionABI = new FunctionABI((string) function["name"], (bool) function["constant"],
+            bool constant = false;
+            if (function.ContainsKey("constant"))
+            {
+                constant = (bool)function["constant"];
+            }
+            else
+            {
+                // for solidity >=0.6.0
+                if (function.ContainsKey("stateMutability") && ((string)function["stateMutability"] == "view" || (string)function["stateMutability"] == "pure"))
+                    constant = true;
+            }
+
+            var functionABI = new FunctionABI((string) function["name"], constant,
                 TryGetSerpentValue(function));
             functionABI.InputParameters = BuildFunctionParameters((List<object>) function["inputs"]);
             functionABI.OutputParameters = BuildFunctionParameters((List<object>) function["outputs"]);


### PR DESCRIPTION
So in Solidity v0.6.0 onward, the constant keyword has been dropped... So we should check for stateMutability instead.

Changes will look for the constant keyword first (for backwards compatibility). If it does exist, pick up the boolean value from that. Otherwise check for stateMutability, whether it is "view" or "pure" - Which will be flagged as constant = true.

Thanks Juan - Hopefully that short snippet of mine isn't too messy. :) As mentioned will also check on our other repos, e.g. CodeGen (noticed the ABIDeserialiser class there too).