### PR TITLE
Getting compressed public key from EthECKey

### DIFF
--- a/src/Nethereum.Signer/EthECKey.cs
+++ b/src/Nethereum.Signer/EthECKey.cs
@@ -119,14 +119,14 @@ namespace Nethereum.Signer
             return GetPrivateKeyAsBytes().ToHex(true);
         }
 
-        public byte[] GetPubKey()
+        public byte[] GetPubKey(bool compressed = false)
         {
-            return _ecKey.GetPubKey(false);
+            return _ecKey.GetPubKey(compressed);
         }
 
-        public byte[] GetPubKeyNoPrefix()
+        public byte[] GetPubKeyNoPrefix(bool compressed = false)
         {
-            var pubKey = _ecKey.GetPubKey(false);
+            var pubKey = _ecKey.GetPubKey(compressed);
             var arr = new byte[pubKey.Length - 1];
             //remove the prefix
             Array.Copy(pubKey, 1, arr, 0, arr.Length);


### PR DESCRIPTION
Added an optional flag to `EthECKey.GetPubKey()` to retrieve the compressed version of a public key.