### PR TITLE
Improved AccountTransactionSigningInterceptor extensibility

### DIFF
--- a/src/Nethereum.Accounts/AccountSignerTransactionManager.cs
+++ b/src/Nethereum.Accounts/AccountSignerTransactionManager.cs
@@ -21,14 +21,13 @@ namespace Nethereum.Web3.Accounts
         private readonly AccountOfflineTransactionSigner _transactionSigner;
         public BigInteger? ChainId { get; private set; }
 
-        public AccountSignerTransactionManager(IClient rpcClient, Account account, BigInteger? chainId = null)
+        public AccountSignerTransactionManager(IClient rpcClient, IAccount account, BigInteger? chainId = null)
         {
             ChainId = chainId;
             Account = account ?? throw new ArgumentNullException(nameof(account));
             Client = rpcClient;
             _transactionSigner = new AccountOfflineTransactionSigner();
         }
-
 
         public AccountSignerTransactionManager(IClient rpcClient, string privateKey, BigInteger? chainId = null)
         {

--- a/src/Nethereum.Accounts/AccountTransactionSigningInterceptor.cs
+++ b/src/Nethereum.Accounts/AccountTransactionSigningInterceptor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Nethereum.JsonRpc.Client;
+using Nethereum.RPC.Accounts;
 using Nethereum.RPC.Eth.DTOs;
 
 namespace Nethereum.Web3.Accounts
@@ -12,6 +13,11 @@ namespace Nethereum.Web3.Accounts
         public AccountTransactionSigningInterceptor(string privateKey, IClient client)
         {
             signer = new AccountSignerTransactionManager(client, privateKey);
+        }
+
+        public AccountTransactionSigningInterceptor(IAccount account, IClient client)
+        {
+            signer = new AccountSignerTransactionManager(client, account);
         }
 
         public override async Task<object> InterceptSendRequestAsync<TResponse>(


### PR DESCRIPTION
Improved extensibility of the AccountTransactionSigningInterceptor by allowing use of custom account implementation.

The  use of `IAccount` instead of `Account` in `AccountSignerTransactionManager` makes the implementation more modular. 
The addition of ctor in AccountTransactionSigningInterceptor allows the interceptor to accept custom account implementations.