### PR TITLE
Geth API: DebugTraceBlock methods fixed and updated

### DIFF
--- a/src/Nethereum.Geth/RPC/GethDebug/DTOs/TraceTransactionOptions.cs
+++ b/src/Nethereum.Geth/RPC/GethDebug/DTOs/TraceTransactionOptions.cs
@@ -30,5 +30,20 @@ namespace Nethereum.Geth.RPC.Debug.DTOs
         /// </summary>
         [DataMember(Name = "fullStorage")]
         public bool FullStorage { get; set; }
+        
+        /// <summary>
+        /// Setting this will enable JavaScript-based transaction tracing, described below.
+        /// If set, the previous four arguments will be ignored.
+        /// </summary>
+        [DataMember(Name = "tracer")]
+        public string Tracer { get; set; }
+
+        /// <summary>
+        /// Overrides the default timeout of 5 seconds for JavaScript-based tracing calls. Valid values are described here:
+        /// https://golang.org/pkg/time/#ParseDuration
+        /// </summary>
+        [DataMember(Name = "timeout")]
+        public string Timeout { get; set; }
+        
     }
 }

--- a/src/Nethereum.Geth/RPC/GethDebug/DebugTraceBlock.cs
+++ b/src/Nethereum.Geth/RPC/GethDebug/DebugTraceBlock.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Nethereum.Geth.RPC.Debug.DTOs;
 using Nethereum.JsonRpc.Client;
 using Newtonsoft.Json.Linq;
 
@@ -8,20 +9,20 @@ namespace Nethereum.Geth.RPC.Debug
     ///     The traceBlock method will return a full stack trace of all invoked opcodes of all transaction that were included
     ///     included in this block. Note, the parent of this block must be present or it will fail.
     /// </Summary>
-    public class DebugTraceBlock : RpcRequestResponseHandler<JObject>, IDebugTraceBlock
+    public class DebugTraceBlock : RpcRequestResponseHandler<JArray>, IDebugTraceBlock
     {
         public DebugTraceBlock(IClient client) : base(client, ApiMethods.debug_traceBlock.ToString())
         {
         }
 
-        public RpcRequest BuildRequest(string blockRlpHex, object id = null)
+        public RpcRequest BuildRequest(string blockRlpHex, TraceTransactionOptions options, object id = null)
         {
-            return base.BuildRequest(id, blockRlpHex);
+            return base.BuildRequest(id, blockRlpHex, options);
         }
 
-        public Task<JObject> SendRequestAsync(string blockRlpHex, object id = null)
+        public Task<JArray> SendRequestAsync(string blockRlpHex, TraceTransactionOptions options, object id = null)
         {
-            return base.SendRequestAsync(id, blockRlpHex);
+            return base.SendRequestAsync(id, blockRlpHex, options);
         }
     }
 }

--- a/src/Nethereum.Geth/RPC/GethDebug/DebugTraceBlockByHash.cs
+++ b/src/Nethereum.Geth/RPC/GethDebug/DebugTraceBlockByHash.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Nethereum.Geth.RPC.Debug.DTOs;
 using Nethereum.JsonRpc.Client;
 using Newtonsoft.Json.Linq;
 
@@ -8,20 +9,20 @@ namespace Nethereum.Geth.RPC.Debug
     ///     Similar to debug_traceBlock, traceBlockByHash accepts a block hash and will replay the block that is already
     ///     present in the database.
     /// </Summary>
-    public class DebugTraceBlockByHash : RpcRequestResponseHandler<JObject>, IDebugTraceBlockByHash
+    public class DebugTraceBlockByHash : RpcRequestResponseHandler<JArray>, IDebugTraceBlockByHash
     {
         public DebugTraceBlockByHash(IClient client) : base(client, ApiMethods.debug_traceBlockByHash.ToString())
         {
         }
 
-        public RpcRequest BuildRequest(string hash, object id = null)
+        public RpcRequest BuildRequest(string hash, TraceTransactionOptions options, object id = null)
         {
-            return base.BuildRequest(id, hash);
+            return base.BuildRequest(id, hash, options);
         }
 
-        public Task<JObject> SendRequestAsync(string hash, object id = null)
+        public Task<JArray> SendRequestAsync(string hash, TraceTransactionOptions options, object id = null)
         {
-            return base.SendRequestAsync(id, hash);
+            return base.SendRequestAsync(id, hash, options);
         }
     }
 }

--- a/src/Nethereum.Geth/RPC/GethDebug/DebugTraceBlockByNumber.cs
+++ b/src/Nethereum.Geth/RPC/GethDebug/DebugTraceBlockByNumber.cs
@@ -1,4 +1,6 @@
 using System.Threading.Tasks;
+using Nethereum.Geth.RPC.Debug.DTOs;
+using Nethereum.Hex.HexTypes;
 using Nethereum.JsonRpc.Client;
 using Newtonsoft.Json.Linq;
 
@@ -8,20 +10,20 @@ namespace Nethereum.Geth.RPC.Debug
     ///     Similar to debug_traceBlock, traceBlockByNumber accepts a block number and will replay the block that is already
     ///     present in the database.
     /// </Summary>
-    public class DebugTraceBlockByNumber : RpcRequestResponseHandler<JObject>, IDebugTraceBlockByNumber
+    public class DebugTraceBlockByNumber : RpcRequestResponseHandler<JArray>, IDebugTraceBlockByNumber
     {
         public DebugTraceBlockByNumber(IClient client) : base(client, ApiMethods.debug_traceBlockByNumber.ToString())
         {
         }
 
-        public RpcRequest BuildRequest(ulong blockNumber, object id = null)
+        public RpcRequest BuildRequest(ulong blockNumber, TraceTransactionOptions options, object id = null)
         {
-            return base.BuildRequest(id, blockNumber);
+            return base.BuildRequest(id, new HexBigInteger(blockNumber), options);
         }
 
-        public Task<JObject> SendRequestAsync(ulong blockNumber, object id = null)
+        public Task<JArray> SendRequestAsync(ulong blockNumber, TraceTransactionOptions options, object id = null)
         {
-            return base.SendRequestAsync(id, blockNumber);
+            return base.SendRequestAsync(id, new HexBigInteger(blockNumber), options);
         }
     }
 }

--- a/src/Nethereum.Geth/RPC/GethDebug/DebugTraceBlockFromFile.cs
+++ b/src/Nethereum.Geth/RPC/GethDebug/DebugTraceBlockFromFile.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Nethereum.Geth.RPC.Debug.DTOs;
 using Nethereum.JsonRpc.Client;
 using Newtonsoft.Json.Linq;
 
@@ -7,20 +8,20 @@ namespace Nethereum.Geth.RPC.Debug
     /// <Summary>
     ///     Similar to debug_traceBlock, traceBlockFromFile accepts a file containing the RLP of the block.
     /// </Summary>
-    public class DebugTraceBlockFromFile : RpcRequestResponseHandler<JObject>, IDebugTraceBlockFromFile
+    public class DebugTraceBlockFromFile : RpcRequestResponseHandler<JArray>, IDebugTraceBlockFromFile
     {
         public DebugTraceBlockFromFile(IClient client) : base(client, ApiMethods.debug_traceBlockFromFile.ToString())
         {
         }
          
-        public RpcRequest BuildRequest(string filePath, object id = null)
+        public RpcRequest BuildRequest(string filePath, TraceTransactionOptions options, object id = null)
         {
-            return base.BuildRequest(id, filePath);
+            return base.BuildRequest(id, filePath, options);
         }
 
-        public Task<JObject> SendRequestAsync(string filePath, object id = null)
+        public Task<JArray> SendRequestAsync(string filePath, TraceTransactionOptions options, object id = null)
         {
-            return base.SendRequestAsync(id, filePath);
+            return base.SendRequestAsync(id, filePath, options);
         }
     }
 }

--- a/src/Nethereum.Geth/RPC/GethDebug/IDebugTraceBlock.cs
+++ b/src/Nethereum.Geth/RPC/GethDebug/IDebugTraceBlock.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Nethereum.Geth.RPC.Debug.DTOs;
 using Nethereum.JsonRpc.Client;
 using Newtonsoft.Json.Linq;
 
@@ -6,7 +7,7 @@ namespace Nethereum.Geth.RPC.Debug
 {
     public interface IDebugTraceBlock
     {
-        RpcRequest BuildRequest(string blockRlpHex, object id = null);
-        Task<JObject> SendRequestAsync(string blockRlpHex, object id = null);
+        RpcRequest BuildRequest(string blockRlpHex, TraceTransactionOptions options, object id = null);
+        Task<JArray> SendRequestAsync(string blockRlpHex, TraceTransactionOptions options, object id = null);
     }
 }

--- a/src/Nethereum.Geth/RPC/GethDebug/IDebugTraceBlockByHash.cs
+++ b/src/Nethereum.Geth/RPC/GethDebug/IDebugTraceBlockByHash.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Nethereum.Geth.RPC.Debug.DTOs;
 using Nethereum.JsonRpc.Client;
 using Newtonsoft.Json.Linq;
 
@@ -6,7 +7,7 @@ namespace Nethereum.Geth.RPC.Debug
 {
     public interface IDebugTraceBlockByHash
     {
-        RpcRequest BuildRequest(string hash, object id = null);
-        Task<JObject> SendRequestAsync(string hash, object id = null);
+        RpcRequest BuildRequest(string hash, TraceTransactionOptions options, object id = null);
+        Task<JArray> SendRequestAsync(string hash,TraceTransactionOptions options, object id = null);
     }
 }

--- a/src/Nethereum.Geth/RPC/GethDebug/IDebugTraceBlockByNumber.cs
+++ b/src/Nethereum.Geth/RPC/GethDebug/IDebugTraceBlockByNumber.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Nethereum.Geth.RPC.Debug.DTOs;
 using Nethereum.JsonRpc.Client;
 using Newtonsoft.Json.Linq;
 
@@ -6,7 +7,7 @@ namespace Nethereum.Geth.RPC.Debug
 {
     public interface IDebugTraceBlockByNumber
     {
-        RpcRequest BuildRequest(ulong blockNumber, object id = null);
-        Task<JObject> SendRequestAsync(ulong blockNumber, object id = null);
+        RpcRequest BuildRequest(ulong blockNumber, TraceTransactionOptions options, object id = null);
+        Task<JArray> SendRequestAsync(ulong blockNumber, TraceTransactionOptions options = null, object id = null);
     }
 }

--- a/src/Nethereum.Geth/RPC/GethDebug/IDebugTraceBlockFromFile.cs
+++ b/src/Nethereum.Geth/RPC/GethDebug/IDebugTraceBlockFromFile.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Nethereum.Geth.RPC.Debug.DTOs;
 using Nethereum.JsonRpc.Client;
 using Newtonsoft.Json.Linq;
 
@@ -6,7 +7,7 @@ namespace Nethereum.Geth.RPC.Debug
 {
     public interface IDebugTraceBlockFromFile
     {
-        RpcRequest BuildRequest(string filePath, object id = null);
-        Task<JObject> SendRequestAsync(string filePath, object id = null);
+        RpcRequest BuildRequest(string filePath, TraceTransactionOptions options, object id = null);
+        Task<JArray> SendRequestAsync(string filePath, TraceTransactionOptions options, object id = null);
     }
 }


### PR DESCRIPTION
- block number format fix
- result parsing as JArray
- trace options added to the traceBlock requests
- Tracer and Timeout added to TraceTransactionOptions

For the reference: [documentation about debug_traceBlock Geth methods](https://geth.ethereum.org/docs/rpc/ns-debug#debug_traceblock)