### PR TITLE
Fixed the error handling in StreamingWebSocketClient

### DIFF
--- a/src/Nethereum.JsonRpc.WebSocketClient/WebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/WebSocketClient.cs
@@ -87,7 +87,7 @@ namespace Nethereum.JsonRpc.WebSocketClient
             }
             catch (TaskCanceledException ex)
             {
-                throw new RpcClientTimeoutException($"Rpc timeout after {ConnectionTimeout.TotalMilliseconds} milliseconds", ex);
+                throw new RpcClientTimeoutException($"Rpc timeout after {ForceCompleteReadTotalMilliseconds} milliseconds", ex);
             }
         }
 


### PR DESCRIPTION
Disposing the member fields when encountered an error will result in the message handling loops to throw. The disposing should only be done when the parent class is being disposed. Before the changes, the https://github.com/Nethereum/Nethereum/blob/3f644c4a301bcb89810dfcb42f25d8c7c2cd2f42/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs#L277 line was randomly throwing NullReferenceExceptions.