### PR TITLE
WebSocketClient, fixed starvation condition

### DIFF
--- a/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
+++ b/src/Nethereum.JsonRpc.WebSocketClient/StreamingWebSocketClient.cs
@@ -120,11 +120,6 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
                 _cancellationTokenSource = new CancellationTokenSource();
             }
 
-            _listener = Task.Factory.StartNew(async () =>
-            {
-                await HandleIncomingMessagesAsync();
-            }, _cancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Current);
-
             return ConnectWebSocketAsync();
         }
 
@@ -150,6 +145,11 @@ namespace Nethereum.JsonRpc.WebSocketStreamingClient
                     }
 
                     await _clientWebSocket.ConnectAsync(new Uri(_path), tokenSource.Token).ConfigureAwait(false);
+                    
+                    _listener = Task.Factory.StartNew(async () =>
+                    {
+                        await HandleIncomingMessagesAsync();
+                    }, _cancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Current);
 
                     //Random random = new Random();
                     //var x = random.Next(0, 30);


### PR DESCRIPTION
If method "HandleIncomingMessagesAsync()" is called before the websocket client is connected, the while() loop will get stuck in starvation condition, making continuous comparison without any CPU pause. This won't allow "_clientWebSocket" to connect, because CPU is stuck in that method, not allowing any other tasks to continue.

I propose initializing the listener when "_clientWebSocket" is already connected. Other solutions may be proposed, with AutoRaiseEvent when a request is added to "_requests", if you do not like to initilize the listener at this point. 

Starvation condition is tested and triggered in Ubuntu 21.04 (and I suppose it is happening in another OS). When "StreamingWebSocketClient" is instantiated in any project, the program will be stuck by 100% CPU usage, 