### PR TITLE
Fixed the race condition in StreamingWebSocketClient

### DIFF
--- a/consoletests/Nethereum.WebSocketsStreamingTest/Program.cs
+++ b/consoletests/Nethereum.WebSocketsStreamingTest/Program.cs
@@ -130,10 +130,6 @@ namespace Nethereum.WebSocketsStreamingTest
                 Console.WriteLine("Logs error info:" + exception.Message);
             });
 
-            
-
-
-
             await client.StartAsync();
 
             blockHeaderSubscription.SubscribeAsync().Wait();
@@ -150,10 +146,10 @@ namespace Nethereum.WebSocketsStreamingTest
 
             //await ethLogsTokenTransfer.SubscribeAsync(filterTransfers);
 
-            //Thread.Sleep(30000);
+            //await Task.Delay(30000);
             //pendingTransactionsSubscription.UnsubscribeAsync().Wait();
 
-            //Thread.Sleep(20000);
+            //await Task.Delay(20000);
 
             //blockHeaderSubscription.UnsubscribeAsync().Wait();
 
@@ -166,8 +162,6 @@ namespace Nethereum.WebSocketsStreamingTest
         private static async void Client_Error(object sender, Exception ex)
         {
             Console.WriteLine("Client Error restarting...");
-           // ((StreamingWebSocketClient)sender).Error -= Client_Error;
-            ((StreamingWebSocketClient)sender).Dispose();
             await SubscribeAndRunAsync();
         }
 


### PR DESCRIPTION
- Fixed the race condition in StreamingWebSocketClient
- Made `StreamingWebSocketClient.StopAsync` and `StreamingWebSocketClient.StartAsync` thread-safe
- Included the changes in #738
- Fixed the problem where the _listener task exited immediately thus couldn't be waited. [Read here](https://web.archive.org/web/20211024154049/https://sergeyteplyakov.github.io/Blog/async/2019/05/21/The-Dangers-of-Task.Factory.StartNew.html) for more information.
- The listener now quits when the WebSocket disconnects.

Please don't add null checks to the `HandleIncomingMessagesAsync` function as the StopAsync function now properly waits for the listener to exit, doing so would make actual bugs harder to catch.
The function also must not check the `_clientWebSocket`'s state as the listener should be stopped once the connection is dropped. A properly implemented code would call the `StartAsync` in the `Error` handler if the aim is to reconnect on `Errors`.