### PR TITLE
Replace Microsoft.Azure.KeyVault with Azure.Security.KeyVault.Keys

### DIFF
--- a/consoletests/Nethereum.Signer.AzureKeyVault.Console/Nethereum.Signer.AzureKeyVault.Console.csproj
+++ b/consoletests/Nethereum.Signer.AzureKeyVault.Console/Nethereum.Signer.AzureKeyVault.Console.csproj
@@ -6,7 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.0" />
+    <PackageReference Include="Azure.Identity" Version="1.5.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" />
   </ItemGroup>
 

--- a/src/Nethereum.Signer.AzureKeyVault/Nethereum.Signer.AzureKeyVault.csproj
+++ b/src/Nethereum.Signer.AzureKeyVault/Nethereum.Signer.AzureKeyVault.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461'">


### PR DESCRIPTION
**This is a breaking change** to the `AzureKeyVaultExternalSigner` class as its constructors are now updated with types from the [Azure.Security.KeyVault.Keys](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/keyvault/Azure.Security.KeyVault.Keys) package.

The logic is the same, just a small refactoring. As the `Azure.Security.KeyVault.Keys` package doesn't support some obsolete target frameworks used in this project, there might be problems with them.

The console test has been updated as well to show how to use the new constructors with [`TokenCredential`](https://docs.microsoft.com/en-us/dotnet/api/azure.core.tokencredential?view=azure-dotnet) instances.

