### PR TITLE
Fix obsolete message

### DIFF
--- a/src/Nethereum.Contracts/ContractHandlers/ContractTransactionHandler.cs
+++ b/src/Nethereum.Contracts/ContractHandlers/ContractTransactionHandler.cs
@@ -38,7 +38,7 @@ namespace Nethereum.Contracts.ContractHandlers
             return _receiptPollHandler.SendTransactionAsync(contractAddress, functionMessage, tokenSource);
         }
 
-        [Obsolete("Use SendTransactionAndWaitForReceiptAsync instead")]
+        [Obsolete("Use " + nameof(SendTransactionAndWaitForReceiptAsync) + " instead")]
         public Task<TransactionReceipt> SendRequestAndWaitForReceiptAsync(
             string contractAddress, TContractMessage functionMessage = null, CancellationTokenSource tokenSource = null)
         {
@@ -50,7 +50,7 @@ namespace Nethereum.Contracts.ContractHandlers
             return _transactionSenderHandler.SendTransactionAsync(contractAddress, functionMessage);
         }
 
-        [Obsolete("Use SendTransactionAsync instead")]
+        [Obsolete("Use " + nameof(SendTransactionAsync) + " instead")]
         public Task<string> SendRequestAsync(string contractAddress, TContractMessage functionMessage = null)
         {
             return SendTransactionAsync(contractAddress, functionMessage);

--- a/src/Nethereum.Contracts/ContractHandlers/ContractTransactionHandler.cs
+++ b/src/Nethereum.Contracts/ContractHandlers/ContractTransactionHandler.cs
@@ -38,7 +38,7 @@ namespace Nethereum.Contracts.ContractHandlers
             return _receiptPollHandler.SendTransactionAsync(contractAddress, functionMessage, tokenSource);
         }
 
-        [Obsolete("Use SendTransactionAndWaitForReceipt instead")]
+        [Obsolete("Use SendTransactionAndWaitForReceiptAsync instead")]
         public Task<TransactionReceipt> SendRequestAndWaitForReceiptAsync(
             string contractAddress, TContractMessage functionMessage = null, CancellationTokenSource tokenSource = null)
         {


### PR DESCRIPTION
`SendTransactionAndWaitForReceipt` should be `SendTransactionAndWaitForReceiptAsync` in the obsolete message.

I also used `nameof` so that the compiler can help check for method name consistencies.