### PR TITLE
Update ConvertorForRLPEncodingExtensions.cs

### DIFF
--- a/src/Nethereum.RLP/ConvertorForRLPEncodingExtensions.cs
+++ b/src/Nethereum.RLP/ConvertorForRLPEncodingExtensions.cs
@@ -70,7 +70,8 @@ namespace Nethereum.RLP
             if (BitConverter.IsLittleEndian)
                 bytes = bytes.Reverse().ToArray();
 
-            return TrimZeroBytes(bytes);
+            var trimmed = TrimZeroBytes(bytes);
+            return trimmed.Any() ? trimmed : new byte[1];
         }
 
         public static byte[] TrimZeroBytes(this byte[] bytes)


### PR DESCRIPTION
Updated ToBytesFromNumber() to return a single zero byte instead of an empty array when converting a zero value. This fixes the ToBytesForRLPEncoding() extension methods returning empty arrays on zero values.