### PR TITLE
fix: "Method not found: txpool_BesuStatistics" - besu TXPOOL methods have to be lowercase

### DIFF
--- a/src/Nethereum.Besu/ApiMethods.cs
+++ b/src/Nethereum.Besu/ApiMethods.cs
@@ -30,8 +30,8 @@
         perm_reloadPermissionsFromFile,
         perm_removeAccountsFromWhitelist,
         perm_removeNodesFromWhitelist,
-        txpool_BesuStatistics,
-        txpool_BesuTransactions,
+        txpool_besuStatistics,
+        txpool_besuTransactions,
         eea_getTransactionReceipt,
         eea_sendRawTransaction
     }

--- a/src/Nethereum.Besu/RPC/Txpool/TxpoolPantheonStatistics.cs
+++ b/src/Nethereum.Besu/RPC/Txpool/TxpoolPantheonStatistics.cs
@@ -9,7 +9,7 @@ namespace Nethereum.Besu.RPC.Txpool
     /// </Summary>
     public class TxpoolBesuStatistics : GenericRpcRequestResponseHandlerNoParam<JObject>, ITxpoolBesuStatistics
     {
-        public TxpoolBesuStatistics(IClient client) : base(client, ApiMethods.txpool_BesuStatistics.ToString())
+        public TxpoolBesuStatistics(IClient client) : base(client, ApiMethods.txpool_besuStatistics.ToString())
         {
         }
     }

--- a/src/Nethereum.Besu/RPC/Txpool/TxpoolPantheonTransactions.cs
+++ b/src/Nethereum.Besu/RPC/Txpool/TxpoolPantheonTransactions.cs
@@ -11,7 +11,7 @@ namespace Nethereum.Besu.RPC.Txpool
         ITxpoolBesuTransactions
     {
         public TxpoolBesuTransactions(IClient client) : base(client,
-            ApiMethods.txpool_BesuTransactions.ToString())
+            ApiMethods.txpool_besuTransactions.ToString())
         {
         }
     }


### PR DESCRIPTION
as described in the besu documentation https://besu.hyperledger.org/en/stable/Reference/API-Methods/#txpool_besustatistics
this is to avoid an e.g. "Method not found: txpool_BesuStatistics" exception