### PR TITLE
Fixing issue with Log Orchestrator / Blockchain Processor infinite loop

### DIFF
--- a/src/Nethereum.BlockchainProcessing/LogProcessing/LogOrchestrator.cs
+++ b/src/Nethereum.BlockchainProcessing/LogProcessing/LogOrchestrator.cs
@@ -40,7 +40,7 @@ namespace Nethereum.BlockchainProcessing.LogProcessing
             var nextBlockNumberFrom = fromNumber;
             try
             {
-                while (!progress.HasErrored && progress.BlockNumberProcessTo != toNumber)
+                while (!progress.HasErrored && progress.BlockNumberProcessTo != toNumber && !cancellationToken.IsCancellationRequested)
                 {
                     if (progress.BlockNumberProcessTo != null)
                     {

--- a/src/Nethereum.RPC/Eth/Blocks/LastConfirmedBlockNumberService.cs
+++ b/src/Nethereum.RPC/Eth/Blocks/LastConfirmedBlockNumberService.cs
@@ -53,13 +53,11 @@ namespace Nethereum.RPC.Eth.Blocks
 
             while (!IsBlockNumberConfirmed(waitForConfirmedBlockNumber, currentBlockOnChain.Value, _minimumBlockConfirmations))
             {
-                if (!cancellationToken.IsCancellationRequested)
-                {
-                    attemptCount++;
-                    LogWaitingForBlockAvailability(currentBlockOnChain, _minimumBlockConfirmations, waitForConfirmedBlockNumber, attemptCount);
-                    await _waitStrategy.ApplyAsync(attemptCount).ConfigureAwait(false);
-                    currentBlockOnChain = await GetCurrentBlockOnChainAsync().ConfigureAwait(false);
-                }
+                cancellationToken.ThrowIfCancellationRequested();
+                attemptCount++;
+                LogWaitingForBlockAvailability(currentBlockOnChain, _minimumBlockConfirmations, waitForConfirmedBlockNumber, attemptCount);
+                await _waitStrategy.ApplyAsync(attemptCount).ConfigureAwait(false);
+                currentBlockOnChain = await GetCurrentBlockOnChainAsync().ConfigureAwait(false);
             }
 
             return currentBlockOnChain;


### PR DESCRIPTION
Fixing issue with Log Orchestrator / Blockchain Processor being stuck in an infinite loop when a cancellation is requested.

With reference to conversation with @juanfranblanco  in previous abandoned PR #810 