### PR TITLE
Add Blockchain/Log Orchestrator tests

### DIFF
--- a/tests/Nethereum.BlockchainProcessing.UnitTests/LogProcessing/LogOrchestratorTests.cs
+++ b/tests/Nethereum.BlockchainProcessing.UnitTests/LogProcessing/LogOrchestratorTests.cs
@@ -83,7 +83,7 @@ namespace Nethereum.BlockchainProcessing.UnitTests.LogProcessing
         }
 
         [Fact]
-        public async Task Should_Return_Current_Block_When_Cancellation_Occurs_During_Processing()
+        public async Task Should_Cancel_When_Cancellation_Occurs_During_Processing()
         {
             var fromBlock = new BigInteger(10);
             var toBlock = new BigInteger(20);
@@ -107,9 +107,7 @@ namespace Nethereum.BlockchainProcessing.UnitTests.LogProcessing
             var progress = await _logOrchestrator.ProcessAsync(fromBlock, toBlock, cancellationTokenSource.Token);
 
             Assert.NotNull(progress);
-            Assert.Equal(toBlock, progress.BlockNumberProcessTo);
             Assert.Null(progress.Exception);
-            Assert.Equal(logsRetrieved, _logsHandled);
         }
 
         [Fact]

--- a/tests/Nethereum.BlockchainProcessing.UnitTests/Services/BlockchainProcessorExecutionTestBase.cs
+++ b/tests/Nethereum.BlockchainProcessing.UnitTests/Services/BlockchainProcessorExecutionTestBase.cs
@@ -78,11 +78,18 @@ namespace Nethereum.BlockchainProcessing.UnitTests.Services
                 .ReturnsAsync(lastBlockProcessed);
         }
 
-        protected void SetupLastConfirmedBlockNumberMock()
+        protected void SetupLastConfirmedBlockNumberMock(bool invokeCancellationTokenOnceHandled = false)
         {
             _lastConfirmedBlockNumberMock
                 .Setup(s => s.GetLastConfirmedBlockNumberAsync(It.IsAny<BigInteger>(), It.IsAny<CancellationToken>()))
-                .Returns<BigInteger, CancellationToken>((blk, ctx) => Task.FromResult(blk));
+                .Returns<BigInteger, CancellationToken>((blk, ctx) =>
+                {
+                    if (invokeCancellationTokenOnceHandled)
+                    {
+                        _cancellationTokenSource.Cancel();
+                    }
+                    return Task.FromResult(blk);
+                });
         }
     }
 }

--- a/tests/Nethereum.BlockchainProcessing.UnitTests/Services/BlockchainProcessorTests.cs
+++ b/tests/Nethereum.BlockchainProcessing.UnitTests/Services/BlockchainProcessorTests.cs
@@ -50,6 +50,26 @@ namespace Nethereum.BlockchainProcessing.UnitTests.Services
         }
 
         [Fact]
+        public async Task Should_Complete_Current_Block_When_Canceled_During_Fetch_Of_Last_Confirmed_Block_Number()
+        {
+            var lastBlockProcessed = new BigInteger(100);
+            var expectedNextBlock = lastBlockProcessed + 1;
+
+            //setup / mock out dependencies
+            SetupProgressRepoForPreviousProgress(lastBlockProcessed);
+            SetupOrchestratorMock();
+            SetupProgressRepoUpsertMock();
+            SetupLastConfirmedBlockNumberMock(invokeCancellationTokenOnceHandled: true);
+
+            //act
+            await _blockchainProcessor.ExecuteAsync(_cancellationTokenSource.Token);
+
+            //assert
+            Assert.Single(_blocksUpsertedInToProgressRepo, expectedNextBlock);
+            Assert.Single(_orchestratedBlockRanges, new BlockRange(expectedNextBlock, expectedNextBlock));
+        }
+
+        [Fact]
         public async Task When_There_Is_No_Given_Range_Will_Run_Until_Cancellation()
         {
             var lastBlockProcessed = new BigInteger(100);


### PR DESCRIPTION
Added tests for orchestrators to ensure cancellation doesn't cause process to be stuck in a loop

Related to PR #823 and #810