### PR TITLE
RPC.Eth: workaround in EthGetCode to allow [] as return value

### DIFF
--- a/src/Nethereum.RPC/Eth/Exceptions/UnexpectedReplyException.cs
+++ b/src/Nethereum.RPC/Eth/Exceptions/UnexpectedReplyException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Nethereum.RPC.Eth.Exceptions
+{
+    public class UnexpectedReplyException : Exception
+    {
+        public UnexpectedReplyException(string message, object resultValue) : base(message)
+        {
+            ResultValue = resultValue;
+        }
+        public object ResultValue { get; set; }
+    }
+}


### PR DESCRIPTION
Some servers, like `nodes.mewapi.io/rpc/eth` and `www.ethercluster.com/etc`,
return empty array instead of "0x" for non-contract addresses.
Example: `{"jsonrpc":"2.0","id":1,"result":[]}`.
Handle that case and return "0x".
In case of non-empty array, throw UnexpectedReplyException.