### PR TITLE
Fix: Metamask Interceptor fail on call eth_estimateGas when from is requiered

### DIFF
--- a/src/Nethereum.Metamask/MetamaskInterceptor.cs
+++ b/src/Nethereum.Metamask/MetamaskInterceptor.cs
@@ -31,6 +31,15 @@ namespace Nethereum.Metamask
                     request.RawParameters)).ConfigureAwait(false);
                 return ConvertResponse<T>(response);
             } 
+            else if (request.Method == "eth_estimateGas") 
+            {
+                var transaction = (CallInput)request.RawParameters[0];
+                transaction.From = _metamaskHostProvider.SelectedAccount;
+                request.RawParameters[0] = transaction;
+                var response = await _metamaskInterop.SendAsync(new MetamaskRpcRequestMessage(request.Id, request.Method, GetSelectedAccount(),
+                    request.RawParameters)).ConfigureAwait(false);
+                return ConvertResponse<T>(response);
+            } 
             else if ( request.Method == "eth_signTypedData_v4" )
             {
                 var account = GetSelectedAccount();

--- a/src/Nethereum.Metamask/MetamaskInterceptor.cs
+++ b/src/Nethereum.Metamask/MetamaskInterceptor.cs
@@ -33,9 +33,9 @@ namespace Nethereum.Metamask
             } 
             else if (request.Method == "eth_estimateGas") 
             {
-                var transaction = (CallInput)request.RawParameters[0];
-                transaction.From = _metamaskHostProvider.SelectedAccount;
-                request.RawParameters[0] = transaction;
+                var callinput = (CallInput)request.RawParameters[0];
+                callinput.From ??= _metamaskHostProvider.SelectedAccount;
+                request.RawParameters[0] = callinput;
                 var response = await _metamaskInterop.SendAsync(new MetamaskRpcRequestMessage(request.Id, request.Method, GetSelectedAccount(),
                     request.RawParameters)).ConfigureAwait(false);
                 return ConvertResponse<T>(response);


### PR DESCRIPTION
Add on metamask Interceptor the case for eth_estimateGas and include the acount in field from of CallInput