### PR TITLE
Generator.Console latests frameworks compatility

### DIFF
--- a/generators/Nethereum.Generator.Console/Nethereum.Generator.Console.csproj
+++ b/generators/Nethereum.Generator.Console/Nethereum.Generator.Console.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\buildConf\Generic-CodeGen.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64;</RuntimeIdentifiers>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
Hello, I tried using Nethereum.Generator.Console and it wouldn't work because I don't have the framework netcore3.1. 
I'm on linux and I only installed net6 and net7.

I updated the csproj to target more recent frameworks. 
It works if I package it and install it using theses commands from inside the generators/Nethereum.Generator.Console directory.
```bash
dotnet pack
dotnet tool install Nethereum.Generator.Console --add-source bin/Debug/ --global
```