### PR TITLE
Add recover from signature with non standard json

### DIFF
--- a/src/Nethereum.Signer.EIP712/Eip712TypedDataSigner.cs
+++ b/src/Nethereum.Signer.EIP712/Eip712TypedDataSigner.cs
@@ -92,9 +92,9 @@ namespace Nethereum.Signer.EIP712
             return  new MessageSigner().EcRecover(Sha3Keccack.Current.CalculateHash(encodedData), signature);
         }
 
-        public string RecoverFromSignatureV4(string json, string signature)
+        public string RecoverFromSignatureV4(string json, string signature, string messageKeySelector = "message")
         {
-            var encodedData = EncodeTypedData(json);
+            var encodedData = EncodeTypedData<Domain>(json, messageKeySelector);
             return new MessageSigner().EcRecover(Sha3Keccack.Current.CalculateHash(encodedData), signature);
         }
 

--- a/tests/Nethereum.Signer.UnitTests/EIP712NonStandardJsonTest.cs
+++ b/tests/Nethereum.Signer.UnitTests/EIP712NonStandardJsonTest.cs
@@ -60,5 +60,61 @@ namespace Nethereum.Signer.UnitTests
 
             Assert.NotNull(signature);
         }
+
+        [Fact]
+        public void ShouldBeAbleToRecoverSignedNonStandardJsonWithoutDomainTypeDifferentMessageSelectorAndNotPrimaryTypeButOnlyOneType()
+        {
+            //This json has got only one type, so we use the Domain type as it matches it
+            //No primaryType, but we use the first and only type
+            //No message, but instead "value" so we set the "value" as none default.
+            var json = @"{
+                          ""types"": {
+                                        ""FollowWithSig"": [
+                                                  {
+                                                    ""name"": ""profileIds"",
+                                                    ""type"": ""uint256[]""
+                                                  },
+                                                  {
+                                                    ""name"": ""datas"",
+                                                    ""type"": ""bytes[]""
+                                                  },
+                                                  {
+                                                    ""name"": ""nonce"",
+                                                    ""type"": ""uint256""
+                                                  },
+                                                  {
+                                                    ""name"": ""deadline"",
+                                                    ""type"": ""uint256""
+                                                  }
+                                                ]
+                                      },
+
+                            ""value"": {
+                                            ""nonce"": 4,
+                                            ""deadline"": 1670438881,
+                                            ""profileIds"": [
+                                                ""0x5b0f""
+                                                ],
+                                            ""datas"": [
+                                              ""0x""
+                                                ]
+                                        },
+                          ""domain"": {
+                                ""name"": ""Protocol"",
+                                ""chainId"": ""100000000"",
+                                ""verifyingContract"": ""0x60Ae865ee4C725cd04353b5AAb364553f56ceF82"",
+                                ""version"": ""1""
+                                }
+                            }";
+
+
+
+            var signer = new Eip712TypedDataSigner();
+            var key = new EthECKey("94e001d6adf3a3275d5dd45971c2a5f6637d3e9c51f9693f2e678f649e164fa5");
+            string signature = signer.SignTypedDataV4<Domain>(json, key, "value");
+
+            string result = signer.RecoverFromSignatureV4(json, signature, "value");
+            Assert.Equal(result, key.GetPublicAddress());
+        }
     }
 }


### PR DESCRIPTION
This adds a way to recover from signature using the [Non Standard Json approach](https://github.com/Nethereum/Nethereum/blob/cd0f9a25bcc4916da5a5c35022c6ae90c5bb58d5/tests/Nethereum.Signer.UnitTests/EIP712NonStandardJsonTest.cs).