### PR TITLE
Added Openzeppelin's StandardMerkleTree implementation

### DIFF
--- a/src/Nethereum.ABI/ByteArrayConvertors/AbiStructSha3KeccackHashByteArrayConvertor.cs
+++ b/src/Nethereum.ABI/ByteArrayConvertors/AbiStructSha3KeccackHashByteArrayConvertor.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Nethereum.Util;
+using Nethereum.Util.ByteArrayConvertors;
+using Nethereum.Util.HashProviders;
+
+
+namespace Nethereum.ABI.ByteArrayConvertors
+{
+    internal class AbiStructSha3KeccackHashByteArrayConvertor<T> : IByteArrayConvertor<T>
+    {
+        private readonly ABIEncode _abiEncode;
+        public AbiStructSha3KeccackHashByteArrayConvertor()
+        {
+            _abiEncode = new ABIEncode();
+        }
+        public byte[] ConvertToByteArray(T data)
+        {
+            var encoded = _abiEncode.GetABIParamsEncoded(data);
+            return Sha3Keccack.Current.CalculateHash(encoded);
+
+        }
+    }
+}

--- a/src/Nethereum.Merkle/AbiStructSha3KeccackMerkleTree.cs
+++ b/src/Nethereum.Merkle/AbiStructSha3KeccackMerkleTree.cs
@@ -1,0 +1,21 @@
+﻿using Nethereum.ABI.ByteArrayConvertors;
+using Nethereum.Merkle.StrategyOptions.PairingConcat;
+using Nethereum.Util.HashProviders;
+using System.Collections.Generic;
+
+
+namespace Nethereum.Merkle
+{
+
+    public class AbiStructSha3KeccackMerkleTree<T> : MerkleTree<T>
+    {
+        public AbiStructSha3KeccackMerkleTree() : base(new Sha3KeccackHashProvider(), new AbiStructSha3KeccackHashByteArrayConvertor<T>(), PairingConcatType.Sorted)
+        { }
+
+        protected override void InitialiseLeavesAndLayersAndBuildTree(List<MerkleTreeNode> leaves)
+        {
+            leaves.Sort(new MerkleTreeNodeComparer());
+            base.InitialiseLeavesAndLayersAndBuildTree(leaves);
+        }
+    }
+}

--- a/src/Nethereum.Merkle/OpenZeppelinStandardMerkleTree.cs
+++ b/src/Nethereum.Merkle/OpenZeppelinStandardMerkleTree.cs
@@ -1,12 +1,4 @@
-﻿using Nethereum.ABI;
-using Nethereum.Util;
-using Nethereum.Merkle.StrategyOptions.PairingConcat;
-using Nethereum.Util.HashProviders;
-using Nethereum.Util.ByteArrayConvertors;
-using System.Collections.Generic;
-
-
-namespace Nethereum.Merkle
+﻿namespace Nethereum.Merkle
 {
     /// <summary>
     /// Implmentation of OpenZeppelin's StandardMerkleTree, same as https://github.com/OpenZeppelin/merkle-tree/blob/master/src/standard.ts
@@ -14,29 +6,7 @@ namespace Nethereum.Merkle
     /// standard implementation https://github.com/binodnp/openzeppelin-solidity/blob/master/contracts/cryptography/MerkleProof.sol 
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class OpenZeppelinStandardMerkleTree<T> : MerkleTree<T>
+    public class OpenZeppelinStandardMerkleTree<T> : AbiStructSha3KeccackMerkleTree<T>
     {
-        public OpenZeppelinStandardMerkleTree() : base(new Sha3KeccackHashProvider(), new OpenZeppelinByteConverter<T>(), PairingConcatType.Sorted)
-        { }
-        protected override void InitialiseLeavesAndLayersAndBuildTree(List<MerkleTreeNode> leaves)
-        {
-            leaves.Sort(new MerkleTreeNodeComparer());
-            base.InitialiseLeavesAndLayersAndBuildTree(leaves);
-        }
-        
-        private class OpenZeppelinByteConverter<T> : IByteArrayConvertor<T>
-        {
-            private readonly ABIEncode _abiEncode;
-            public OpenZeppelinByteConverter()
-            {
-                _abiEncode = new ABIEncode();
-            }
-            public byte[] ConvertToByteArray(T data)
-            {
-                var encoded = _abiEncode.GetABIParamsEncoded(data);
-                return Sha3Keccack.Current.CalculateHash(encoded);
-
-            }
-        }
     }
 }

--- a/src/Nethereum.Merkle/OpenZeppelinStandardMerkleTree.cs
+++ b/src/Nethereum.Merkle/OpenZeppelinStandardMerkleTree.cs
@@ -1,0 +1,42 @@
+﻿using Nethereum.ABI;
+using Nethereum.Util;
+using Nethereum.Merkle.StrategyOptions.PairingConcat;
+using Nethereum.Util.HashProviders;
+using Nethereum.Util.ByteArrayConvertors;
+using System.Collections.Generic;
+
+
+namespace Nethereum.Merkle
+{
+    /// <summary>
+    /// Implmentation of OpenZeppelin's StandardMerkleTree, same as https://github.com/OpenZeppelin/merkle-tree/blob/master/src/standard.ts
+    /// This can be used to create same proof and tree as OpenZeppelin's JavaScript library and can be used when verifying against their 
+    /// standard implementation https://github.com/binodnp/openzeppelin-solidity/blob/master/contracts/cryptography/MerkleProof.sol 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class OpenZeppelinStandardMerkleTree<T> : MerkleTree<T>
+    {
+        public OpenZeppelinStandardMerkleTree() : base(new Sha3KeccackHashProvider(), new OpenZeppelinByteConverter<T>(), PairingConcatType.Sorted)
+        { }
+        protected override void InitialiseLeavesAndLayersAndBuildTree(List<MerkleTreeNode> leaves)
+        {
+            leaves.Sort(new MerkleTreeNodeComparer());
+            base.InitialiseLeavesAndLayersAndBuildTree(leaves);
+        }
+        
+        private class OpenZeppelinByteConverter<T> : IByteArrayConvertor<T>
+        {
+            private readonly ABIEncode _abiEncode;
+            public OpenZeppelinByteConverter()
+            {
+                _abiEncode = new ABIEncode();
+            }
+            public byte[] ConvertToByteArray(T data)
+            {
+                var encoded = _abiEncode.GetABIParamsEncoded(data);
+                return Sha3Keccack.Current.CalculateHash(encoded);
+
+            }
+        }
+    }
+}

--- a/tests/Nethereum.Contracts.IntegrationTests/MerkleDrop/OpenZeppelinMerkleUnitTests.cs
+++ b/tests/Nethereum.Contracts.IntegrationTests/MerkleDrop/OpenZeppelinMerkleUnitTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nethereum.ABI.FunctionEncoding.Attributes;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Xunit;
+using Nethereum.Merkle;
+using System.Numerics;
+
+namespace Nethereum.Contracts.IntegrationTests.MerkleDrop
+{
+    public class OpenZeppelinMerkleUnitTests
+    {
+        [Fact]
+        public void SingleParamSingleItemHash()
+        {
+            var expected = "0x3f4a1640bcca71e45d053d67ab9891fe44608f4db37cc45e5523588c76c79539";
+            var item = new SingleParam { User = "0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5" };
+
+            var merkleTree = new OpenZeppelinStandardMerkleTree<SingleParam>();
+            merkleTree.BuildTree(new List<SingleParam> { item });
+
+            var hexRoot = merkleTree.Root.Hash.ToHex(true);
+
+            Assert.True(expected.IsTheSameHex(hexRoot));
+        }
+
+        [Fact]
+        public void SingleParamMultipleItems()
+        {
+            var expected = "0xa1b819a3413fb3120a911642ee7fbdb17572e844090a95a0848d07aa230eb702";
+            var item1 = new SingleParam { User = "0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5" };
+            var item2 = new SingleParam { User = "0xA61b1fB89Dd42fcDDD2D3fA19c2B715c426692c7" };
+            var item3 = new SingleParam { User = "0xfa6179E49EE57a06391F218965b35B632F930472" };
+            var item4 = new SingleParam { User = "0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326" };
+
+
+            var items = new List<SingleParam> { item1, item2, item3, item4 };
+
+
+            var merkleTree = new OpenZeppelinStandardMerkleTree<SingleParam>();
+            merkleTree.BuildTree(items);
+
+            var hexRoot = merkleTree.Root.Hash.ToHex(true);
+            Assert.True(expected.IsTheSameHex(hexRoot));
+        }
+
+        [Fact]
+        public void MultiParam_MultipleItems()
+        {
+            var expected = "0xd681161482c0d2826015b40ca9e2595230d62d0041dfe7e37d0f5c5fb3d7e647";
+            var number = 2;
+            var items = new List<MultiParam>
+            {
+                new MultiParam { Number = 2, User = "0xa22003bf951e9a050d4c7600ac1630888ab8d522" },
+                new MultiParam { Number = 2, User = "0xaf2c5c6c4104d62130dd32d442a10f0eb67883db" },
+                new MultiParam { Number = 2, User = "0xaf2c5c6c4104d62130dd32d442a10f0eb67883db" },
+                new MultiParam { Number = 2, User = "0x2721e2fd9de72950ee16a3356ebf29669d11d325" },
+                new MultiParam { Number = 2, User = "0x2721e2fd9de72950ee16a3356ebf29669d11d325" },
+                new MultiParam { Number = 2, User = "0x8b4bc5cb23b2b3a2243e44b7812344949943d608" },
+                new MultiParam { Number = 2, User = "0x8b4bc5cb23b2b3a2243e44b7812344949943d608" },
+                new MultiParam { Number = 2, User = "0xefd394c41d77d38c397e2999470080339e8443f8" },
+                new MultiParam { Number = 2, User = "0xefd394c41d77d38c397e2999470080339e8443f8" },
+                new MultiParam { Number = 2, User = "0xf2ce910fb11ea4abbf7ff0ecdb80527f12f63165" },
+                new MultiParam { Number = 2, User = "0xf2ce910fb11ea4abbf7ff0ecdb80527f12f63165" },
+                new MultiParam { Number = 2, User = "0xa22003bf951e9a050d4c7600ac1630888ab8d522" },
+            };
+
+            var merkleTree = new OpenZeppelinStandardMerkleTree<MultiParam>();
+            merkleTree.BuildTree(items);
+            var hexRoot = merkleTree.Root.Hash.ToHex(true);
+            Assert.True(expected.IsTheSameHex(hexRoot));
+        }
+
+    }
+
+    [Struct("SingleParam")]
+    public class SingleParam
+    {
+        [Parameter("address", 1)]
+        public string User { get; set; }
+    }
+
+    [Struct("MultiParam")]
+    public class MultiParam
+    {
+        [Parameter("address", 1)]
+        public string User { get; set; }
+
+        [Parameter("uint256", "cycle", 2)]
+        public BigInteger Number { get; set; }
+    }
+
+}


### PR DESCRIPTION
Same implementation as openzeppelin's javascript StandardMerkleTree, can be used verify proof generated with their .sol contract.