### PR TITLE
Error handling when building .NET Standard projects

### DIFF
--- a/src/netStandard.bat
+++ b/src/netStandard.bat
@@ -20,7 +20,9 @@ CALL :build
 cd ..
 
 cd Nethereum.Web3
+SET projectName=Nethereum.Web3.csproj
 CALL :build
+SET projectName=
 cd ..
 
 cd Nethereum.JsonRpc.IpcClient*
@@ -133,6 +135,6 @@ EXIT /B %ERRORLEVEL%
 :build
 rem dotnet clean /property:ReleaseSuffix=%releaseSuffix% /property:TargetNetStandard=true /property:TargetNet35=false /property:TargetUnityAOT=false
 rem  dotnet restore /property:ReleaseSuffix=%releaseSuffix% /property:TargetNetStandard=true /property:TargetNet35=false /property:TargetUnityAOT=false
-dotnet build  -c Release /property:ReleaseSuffix=%releaseSuffix% /property:TargetNetStandard=true /property:TargetNet35=false /property:TargetUnityAOT=false
+dotnet build %projectName% -c Release /property:ReleaseSuffix=%releaseSuffix% /property:TargetNetStandard=true /property:TargetNet35=false /property:TargetUnityAOT=false
 xcopy bin\Release\netstandard2.0\*.dll "..\compiledlibraries\netStandard" /s /y
 EXIT /B 0

--- a/src/netStandard.bat
+++ b/src/netStandard.bat
@@ -136,5 +136,9 @@ EXIT /B %ERRORLEVEL%
 rem dotnet clean /property:ReleaseSuffix=%releaseSuffix% /property:TargetNetStandard=true /property:TargetNet35=false /property:TargetUnityAOT=false
 rem  dotnet restore /property:ReleaseSuffix=%releaseSuffix% /property:TargetNetStandard=true /property:TargetNet35=false /property:TargetUnityAOT=false
 dotnet build %projectName% -c Release /property:ReleaseSuffix=%releaseSuffix% /property:TargetNetStandard=true /property:TargetNet35=false /property:TargetUnityAOT=false
-xcopy bin\Release\netstandard2.0\*.dll "..\compiledlibraries\netStandard" /s /y
-EXIT /B 0
+IF %ERRORLEVEL% EQU 0 (
+    xcopy bin\Release\netstandard2.0\*.dll "..\compiledlibraries\netStandard" /s /y
+    EXIT /B 0
+) ELSE (
+    EXIT %ERRORLEVEL%
+)


### PR DESCRIPTION
Previously, the netstandard.bat file was ignoring build errors, for example, building Web3 project was broken because the bat file didn't specify a project name and the folder had two projects but the batch file continued to other projects without failing (returns 0 return-code in the end). This PR aims to fix that.

It's noteworthy to say README badge misrepresents the build status when netstandard.bat fails to build the projects with the following error:
```
D:\a\Nethereum\Nethereum\src\Nethereum.Merkle\AbiStructSha3KeccackMerkleTree.cs(12,91): error CS0122: 'AbiStructSha3KeccackHashByteArrayConvertor<T>' is inaccessible due to its protection level [D:\a\Nethereum\Nethereum\src\Nethereum.Merkle\Nethereum.Merkle.csproj::TargetFramework=netstandard2.0]
```