### PR TITLE
Use IWeb3 instead of Web3 to deploy contracts

### DIFF
--- a/generators/Nethereum.Generators/Service/CSharp/ContractDeploymentServiceMethodsCSharpTemplate.cs
+++ b/generators/Nethereum.Generators/Service/CSharp/ContractDeploymentServiceMethodsCSharpTemplate.cs
@@ -23,19 +23,19 @@ namespace Nethereum.Generators.Service
                 _contractDeploymentCQSMessageModel.GetVariableName();
 
             var sendRequestReceipt =
-                $@"{SpaceUtils.TwoTabs}public static Task<TransactionReceipt> DeployContractAndWaitForReceiptAsync(Nethereum.Web3.Web3 web3, {messageType} {messageVariableName}, CancellationTokenSource cancellationTokenSource = null)
+                $@"{SpaceUtils.TwoTabs}public static Task<TransactionReceipt> DeployContractAndWaitForReceiptAsync(Nethereum.Web3.IWeb3 web3, {messageType} {messageVariableName}, CancellationTokenSource cancellationTokenSource = null)
 {SpaceUtils.TwoTabs}{{
 {SpaceUtils.ThreeTabs}return web3.Eth.GetContractDeploymentHandler<{messageType}>().SendRequestAndWaitForReceiptAsync({messageVariableName}, cancellationTokenSource);
 {SpaceUtils.TwoTabs}}}";
 
             var sendRequest =
-                $@"{SpaceUtils.TwoTabs}public static Task<string> DeployContractAsync(Nethereum.Web3.Web3 web3, {messageType} {messageVariableName})
+                $@"{SpaceUtils.TwoTabs}public static Task<string> DeployContractAsync(Nethereum.Web3.IWeb3 web3, {messageType} {messageVariableName})
 {SpaceUtils.TwoTabs}{{
 {SpaceUtils.ThreeTabs}return web3.Eth.GetContractDeploymentHandler<{messageType}>().SendRequestAsync({messageVariableName});
 {SpaceUtils.TwoTabs}}}";
 
             var sendRequestContract =
-                $@"{SpaceUtils.TwoTabs}public static async Task<{_serviceModel.GetTypeName()}> DeployContractAndGetServiceAsync(Nethereum.Web3.Web3 web3, {messageType} {messageVariableName}, CancellationTokenSource cancellationTokenSource = null)
+                $@"{SpaceUtils.TwoTabs}public static async Task<{_serviceModel.GetTypeName()}> DeployContractAndGetServiceAsync(Nethereum.Web3.IWeb3 web3, {messageType} {messageVariableName}, CancellationTokenSource cancellationTokenSource = null)
 {SpaceUtils.TwoTabs}{{
 {SpaceUtils.ThreeTabs}var receipt = await DeployContractAndWaitForReceiptAsync(web3, {messageVariableName}, cancellationTokenSource);
 {SpaceUtils.ThreeTabs}return new {_serviceModel.GetTypeName()}(web3, receipt.ContractAddress);

--- a/generators/Nethereum.Generators/Service/Vb/ContractDeploymentServiceMethodsVbTemplate.cs
+++ b/generators/Nethereum.Generators/Service/Vb/ContractDeploymentServiceMethodsVbTemplate.cs
@@ -22,21 +22,21 @@ namespace Nethereum.Generators.Service
                 _contractDeploymentCQSMessageModel.GetVariableName();
             
             var sendRequestReceipt =
-                $@"{SpaceUtils.TwoTabs}Public Shared Function DeployContractAndWaitForReceiptAsync(ByVal web3 As Nethereum.Web3.Web3, ByVal {messageVariableName} As {messageType}, ByVal Optional cancellationTokenSource As CancellationTokenSource = Nothing) As Task(Of TransactionReceipt)
+                $@"{SpaceUtils.TwoTabs}Public Shared Function DeployContractAndWaitForReceiptAsync(ByVal web3 As Nethereum.Web3.IWeb3, ByVal {messageVariableName} As {messageType}, ByVal Optional cancellationTokenSource As CancellationTokenSource = Nothing) As Task(Of TransactionReceipt)
 {SpaceUtils.TwoTabs}
 {SpaceUtils.ThreeTabs}Return web3.Eth.GetContractDeploymentHandler(Of {messageType})().SendRequestAndWaitForReceiptAsync({messageVariableName}, cancellationTokenSource)
 {SpaceUtils.TwoTabs}
 {SpaceUtils.TwoTabs}End Function";
 
             var sendRequest =
-                $@"{SpaceUtils.TwoTabs} Public Shared Function DeployContractAsync(ByVal web3 As Nethereum.Web3.Web3, ByVal {messageVariableName} As {messageType}) As Task(Of String)
+                $@"{SpaceUtils.TwoTabs} Public Shared Function DeployContractAsync(ByVal web3 As Nethereum.Web3.IWeb3, ByVal {messageVariableName} As {messageType}) As Task(Of String)
 {SpaceUtils.TwoTabs}
 {SpaceUtils.ThreeTabs}Return web3.Eth.GetContractDeploymentHandler(Of {messageType})().SendRequestAsync({messageVariableName})
 {SpaceUtils.TwoTabs}
 {SpaceUtils.TwoTabs}End Function";
 
             var sendRequestContract =
-                $@"{SpaceUtils.TwoTabs}Public Shared Async Function DeployContractAndGetServiceAsync(ByVal web3 As Nethereum.Web3.Web3, ByVal {messageVariableName} As {messageType}, ByVal Optional cancellationTokenSource As CancellationTokenSource = Nothing) As Task(Of {_serviceModel.GetTypeName()})
+                $@"{SpaceUtils.TwoTabs}Public Shared Async Function DeployContractAndGetServiceAsync(ByVal web3 As Nethereum.Web3.IWeb3, ByVal {messageVariableName} As {messageType}, ByVal Optional cancellationTokenSource As CancellationTokenSource = Nothing) As Task(Of {_serviceModel.GetTypeName()})
 {SpaceUtils.TwoTabs}
 {SpaceUtils.ThreeTabs}Dim receipt = Await DeployContractAndWaitForReceiptAsync(web3, {messageVariableName}, cancellationTokenSource)
 {SpaceUtils.ThreeTabs}Return New {_serviceModel.GetTypeName()}(web3, receipt.ContractAddress)


### PR DESCRIPTION
Hi @juanfranblanco i found where is generated the javascritp that generate the code for the extension.
I change the parameter Web3 for IWeb3 because the code that use web3 inside can do what it needs to do with IWeb3 so i don't see any compatibility problem.

Let me know if this can be done or if you want i can add another set of this method acepting IWeb3 instead of change the current ones.

Thanks!