### PR TITLE
GitHubCI: no need to filter by branch

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,9 +5,7 @@ name: .NET
 
 on:
   push:
-    branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
 
 jobs:
   build:


### PR DESCRIPTION
Removing the branch filters from the GitHub workflows allows potential contributors to see the CI status of their contributions before they propose a PR (therefore allowing them to improve their work before putting it up for review).