### PR TITLE
Request batching for EthSendRawTransaction

### DIFF
--- a/src/Nethereum.RPC/Eth/Transactions/IEthSendRawTransaction.cs
+++ b/src/Nethereum.RPC/Eth/Transactions/IEthSendRawTransaction.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Nethereum.JsonRpc.Client;
 
 namespace Nethereum.RPC.Eth.Transactions
@@ -6,6 +7,10 @@ namespace Nethereum.RPC.Eth.Transactions
     public interface IEthSendRawTransaction
     {
         RpcRequest BuildRequest(string signedTransactionData, object id = null);
+        RpcRequestResponseBatchItem<EthSendRawTransaction, string> CreateBatchItem(string signedTransactionData, object id = null);
+#if !DOTNET35
+        Task<List<string>> SendBatchRequestAsync(params string[] signedTransactionDatas);
+#endif
         Task<string> SendRequestAsync(string signedTransactionData, object id = null);
     }
 }


### PR DESCRIPTION
Similar to batching of other types of rpc requests, this allows for batch sending of raw transactions