### PR TITLE
Fix to make AWSKeyManagementExternalSigner signed messages compatible with EIP-2 

### DIFF
--- a/src/Nethereum.Signer.AWSKeyManagement/AWSKeyManagementExternalSigner.cs
+++ b/src/Nethereum.Signer.AWSKeyManagement/AWSKeyManagementExternalSigner.cs
@@ -75,7 +75,7 @@ namespace Nethereum.Signer.AWSKeyManagement
 
                 var result = await KeyClient.SignAsync(request).ConfigureAwait(false);
 
-                return ECDSASignature.FromDER(result.Signature.ToArray());
+                return ECDSASignature.FromDER(result.Signature.ToArray()).MakeCanonical();
             }
         }
         


### PR DESCRIPTION
ECDSASignature should be made canonical here as Ethereum requires S to be less than secp256k1n/2 as specified in [EIP-2](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md) because of a transaction malleability concern.

It is doing the correct thing for Azure as can be seen here:

https://github.com/Nethereum/Nethereum/blob/a9df163d2a559a3be3e2039457c736bec6f188eb/src/Nethereum.Signer.AzureKeyVault/AzureKeyVaultExternalSigner.cs#L68

Fixing #1035
