### PR TITLE
712 ToJson - Prefix bytes for 1271 AA Type Messages

### DIFF
--- a/src/Nethereum.ABI/EIP712/TypedDataRawJsonConversion.cs
+++ b/src/Nethereum.ABI/EIP712/TypedDataRawJsonConversion.cs
@@ -233,7 +233,7 @@ namespace Nethereum.ABI.EIP712
                         var name = memberName;
                         if (values[i].Value is byte[])
                         {
-                            var value = ((byte[])values[i].Value).ToHex();
+                            var value = ((byte[])values[i].Value).ToHex(true);
                             properties.Add(new JProperty(name, value));
                         }
                         else


### PR DESCRIPTION
Otherwise, the internal message of wrapped Smart Wallet signatures is not verifiable in most cases. Requires redissecting the result of ToJson without this change (specially when using external wallets).