### PR TITLE
Exceptions when validating v indicate that TransactionChainId should be used

### DIFF
--- a/src/Nethereum.Model/LegacyTransaction.cs
+++ b/src/Nethereum.Model/LegacyTransaction.cs
@@ -27,7 +27,7 @@ namespace Nethereum.Model
         private static void ValidateValidV(RLPSignedDataHashBuilder rlpSigner)
         {
             if (rlpSigner.IsVSignatureForChain())
-                throw new Exception("TransactionChainId should be used instead of Transaction");
+                throw new Exception("LegacyTransactionChainId should be used instead of LegacyTransaction");
         }
 
         public LegacyTransaction(byte[] nonce, byte[] gasPrice, byte[] gasLimit, byte[] receiveAddress, byte[] value,

--- a/src/Nethereum.Model/LegacyTransactionChainId.cs
+++ b/src/Nethereum.Model/LegacyTransactionChainId.cs
@@ -33,7 +33,7 @@ namespace Nethereum.Model
         private static void ValidateValidV(RLPSignedDataHashBuilder rlpSigner)
         {
             if (!rlpSigner.IsVSignatureForChain())
-                throw new Exception("Transaction should be used instead of TransactionChainId, invalid V");
+                throw new Exception("LegacyTransaction should be used instead of LegacyTransactionChainId, invalid V");
         }
         private void GetChainIdFromVAndAppendDataForHashRecovery()
         {


### PR DESCRIPTION
Exceptions when validating v indicate that TransactionChainId should be used, when the class is actually LegacyTransactionId.  This typo makes it difficult for someone to correctly understand the error, as TransactionChainId does not exist.