### PR TITLE
fix(spelling): precission -> precision in some places

### DIFF
--- a/src/Nethereum.Util/BigDecimal.cs
+++ b/src/Nethereum.Util/BigDecimal.cs
@@ -110,7 +110,7 @@ namespace Nethereum.Util
         /// <returns>The truncated number</returns>
         internal BigDecimal Truncate(int precision = Precision)
         {
-            //if the precission is 0, 
+            //if the precision is 0, 
             if(precision <= 0) throw new ArgumentException("Precision has to bigger than 0");
             // copy this instance (remember its a struct)
             var shortened = this;
@@ -157,10 +157,10 @@ namespace Nethereum.Util
         /// <returns>The truncated number</returns>
         public BigDecimal Floor()
         {
-            var precission = Mantissa.NumberOfDigits() + Exponent;
-            if (precission <= 0) return 0;
+            var precision = Mantissa.NumberOfDigits() + Exponent;
+            if (precision <= 0) return 0;
 
-            return Truncate(precission);
+            return Truncate(precision);
         }
 
         private static int NumberOfDigits(BigInteger value)

--- a/tests/Nethereum.Util.UnitTests/ConversionTests.cs
+++ b/tests/Nethereum.Util.UnitTests/ConversionTests.cs
@@ -204,7 +204,7 @@ namespace Nethereum.Util.UnitTests
         [InlineData("0.0001", 6, 100)]
         [InlineData("0.001", 6, 1000)]
         [InlineData("1.001", 6, 1001000)]
-        public void ShouldFloorToZeroWhenPrecissionIsZeroOrLower(string value, int numberOfDecimalPlaces, int expected)
+        public void ShouldFloorToZeroWhenPrecisionIsZeroOrLower(string value, int numberOfDecimalPlaces, int expected)
         {
             var unitConversion = new UnitConversion();
             var result = unitConversion.ToWei(decimal.Parse(value), numberOfDecimalPlaces);


### PR DESCRIPTION
I noticed that precision was sometimes (but not always) spelt as precission whilst poking around the source for BigDecimal. I have also renamed the appropriate test. 