### PR TITLE
BigIntger return type for BigDecimal.Floor() and Cast

### DIFF
--- a/src/Nethereum.RPC/Fee1559Suggestions/MedianPriorityFeeHistorySuggestionStrategy.cs
+++ b/src/Nethereum.RPC/Fee1559Suggestions/MedianPriorityFeeHistorySuggestionStrategy.cs
@@ -173,7 +173,7 @@ namespace Nethereum.RPC.Fee1559Suggestions
 
             return new Fee1559()
             {
-                MaxFeePerGas = maxFeePerGas.Value.Floor().Mantissa,
+                MaxFeePerGas = maxFeePerGas.Value.Floor(),
                 MaxPriorityFeePerGas = maxPriorityFeePerGas,
                 BaseFee = baseFee
             };

--- a/src/Nethereum.RPC/Fee1559Suggestions/TimePreferenceSuggestionStrategy.cs
+++ b/src/Nethereum.RPC/Fee1559Suggestions/TimePreferenceSuggestionStrategy.cs
@@ -208,9 +208,9 @@ public static class Comparer
                 }
                 result.Add(new Fee1559()
                 {
-                    BaseFee = bf.Floor().Mantissa,
-                    MaxFeePerGas = (bf + t).Floor().Mantissa,
-                    MaxPriorityFeePerGas = t.Floor().Mantissa
+                    BaseFee = bf.Floor(),
+                    MaxFeePerGas = (bf + t).Floor(),
+                    MaxPriorityFeePerGas = t.Floor()
                 });
             }
 

--- a/src/Nethereum.Util/BigDecimal.cs
+++ b/src/Nethereum.Util/BigDecimal.cs
@@ -9,6 +9,7 @@ namespace Nethereum.Util
     /// Original Author: Jan Christoph Bernack (contact: jc.bernack at googlemail.com)
     /// Changes JB: Added parse, Fix Normalise, Added Floor, New ToString, Change Equals (normalise to validate first), Change Casting to avoid overflows (even if might be slower), Added Normalise Bigger than zero, test on operations, parsing, casting, and other test coverage for ethereum unit conversions
     /// Changes KJ: Added Culture formatting
+    /// Changes ER: Added explicit BigInteger cast, change floor result from BigDecimal to BigInteger
     /// http://stackoverflow.com/a/13813535/956364" />
     /// <summary>
     ///     Arbitrary precision Decimal.
@@ -155,12 +156,12 @@ namespace Nethereum.Util
         ///     Truncate the number, removing all decimal digits.
         /// </summary>
         /// <returns>The truncated number</returns>
-        public BigDecimal Floor()
+        public BigInteger Floor()
         {
             var precision = Mantissa.NumberOfDigits() + Exponent;
             if (precision <= 0) return 0;
 
-            return Truncate(precision);
+            return Truncate(precision).Mantissa;
         }
 
         private static int NumberOfDigits(BigInteger value)
@@ -269,6 +270,11 @@ namespace Nethereum.Util
         public static explicit operator uint(BigDecimal value)
         {
             return Convert.ToUInt32((decimal) value);
+        }
+
+        public static explicit operator BigInteger(BigDecimal value)
+        {
+            return value.Floor();
         }
 
         #endregion

--- a/src/Nethereum.Util/UnitConversion.cs
+++ b/src/Nethereum.Util/UnitConversion.cs
@@ -164,7 +164,7 @@ namespace Nethereum.Util
             var bigDecimalFromUnit = new BigDecimal(fromUnit, 0);
             var conversion = amount * bigDecimalFromUnit;
             var floor = conversion.Floor();
-            return floor.Mantissa;
+            return floor;
         }
 
         public BigInteger ToWei(BigDecimal amount, EthUnit fromUnit = EthUnit.Ether)

--- a/tests/Nethereum.Util.UnitTests/BigDecimalTests.cs
+++ b/tests/Nethereum.Util.UnitTests/BigDecimalTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Globalization;
-
+using System.Numerics;
 using Xunit;
 
 namespace Nethereum.Util.UnitTests
@@ -104,6 +104,40 @@ namespace Nethereum.Util.UnitTests
             var roundedBig = big.RoundAwayFromZero(significantDigits: 0);
 
             Assert.Equal(expected: (BigDecimal)roundedRegular, roundedBig);
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("100000000")]
+        [InlineData("1.1")]
+        [InlineData("1.01")]
+        [InlineData("1.001")]
+        [InlineData("1.0000000001")]
+        [InlineData("123456789.0000000001")]
+        public void ShouldFloorCorrectly(string value)
+        {
+            var bigInt = BigInteger.Parse(value.Split('.')[0]);
+            var bigDecimal = BigDecimal.Parse(value);
+            
+            Assert.Equal(bigInt, bigDecimal.Floor());
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("100000000")]
+        [InlineData("1.1")]
+        [InlineData("1.01")]
+        [InlineData("1.001")]
+        [InlineData("1.0000000001")]
+        [InlineData("123456789.0000000001")]
+        public void ShouldCastToBigIntegerCorrectly(string value)
+        {
+            var bigInt = BigInteger.Parse(value.Split('.')[0]);
+            var bigDecimal = BigDecimal.Parse(value);
+            
+            Assert.Equal(bigInt, (BigInteger)bigDecimal);
         }
 
         [Theory]


### PR DESCRIPTION
Changes the return type of BigDecimal.Floor() from BigDecimal to BigInteger. Also implements a cast that returns the truncated BigDecimal (so same as calling Floor). This is to mimic the behaviour of other casts (e.g. float -> int, decimal -> int) that also truncate on cast.

Breaking change: Calling BigDecimal.Floor() will now return a BigIntger