### PR TITLE
Use BouncyCastle.Cryptography for net6.0 and later

### DIFF
--- a/Nethereum.sln
+++ b/Nethereum.sln
@@ -270,7 +270,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NethereumWCBlazor", "consol
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NethereumWCAvalonia", "consoletests\NethereumWCAvalonia\NethereumWCAvalonia.csproj", "{BBF4CD83-7374-4BFA-B837-F314CCFD977D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NethereumGodotAvalonia", "consoletests\NethereumGodotWCAvalonia\NethereumGodotAvalonia.csproj", "{6AE91750-F47C-4B12-BBA3-0F3DB273D45B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NethereumGodotWCAvalonia", "consoletests\NethereumGodotWCAvalonia\NethereumGodotWCAvalonia.csproj", "{6AE91750-F47C-4B12-BBA3-0F3DB273D45B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Mud", "Mud", "{5B8B052D-60F9-48BD-B186-5EC802731AA9}"
 EndProject

--- a/buildConf/Frameworks.props
+++ b/buildConf/Frameworks.props
@@ -29,7 +29,7 @@
     <ENSFrameworks Condition=" '$(TargetNet472)' == 'true'">net472</ENSFrameworks>
     <ENSFrameworks Condition=" '$(TargetNetCore)' == 'true'">netcoreapp2.1;netcoreapp3.1;net5.0;net8.0</ENSFrameworks>
     <ENSFrameworks Condition=" '$(TargetNetStandard)' == 'true'">netstandard2.0</ENSFrameworks>
-    
+
     <HdWalletFrameworks>netstandard1.1;netstandard2.0;net452;net461;</HdWalletFrameworks>
     <HdWalletFrameworks Condition=" '$(TargetNet461)' == 'true'">net461;</HdWalletFrameworks>
     <HdWalletFrameworks Condition=" '$(TargetNet472)' == 'true'">net472;</HdWalletFrameworks>
@@ -49,25 +49,25 @@
     <IpcWebSocketsFrameworks Condition=" '$(TargetNet472)' == 'true'">net472;</IpcWebSocketsFrameworks>
     <IpcWebSocketsFrameworks Condition=" '$(TargetNetCore)' == 'true'">netcoreapp2.1;netcoreapp3.1;net5.0;net8.0</IpcWebSocketsFrameworks>
     <IpcWebSocketsFrameworks Condition=" '$(TargetNetStandard)' == 'true'">netstandard2.0;</IpcWebSocketsFrameworks>
-	
+
     <ReactiveFrameworks>net461;netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0</ReactiveFrameworks>
     <ReactiveFrameworks Condition=" '$(TargetNet461)' == 'true'">net461;</ReactiveFrameworks>
     <ReactiveFrameworks Condition=" '$(TargetNet472)' == 'true'">net472;</ReactiveFrameworks>
     <ReactiveFrameworks Condition=" '$(TargetNetCore)' == 'true'">netcoreapp2.1;netcoreapp3.1;net5.0;net8.0</ReactiveFrameworks>
     <ReactiveFrameworks Condition=" '$(TargetNetStandard)' == 'true'">netstandard2.0;</ReactiveFrameworks>
-	
+
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-  
+
   <ItemGroup>
      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>	
+  </ItemGroup>
    <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetUnityAOT)' != 'true' And '$(MSBuildProjectName)' != 'Nethereum.HdWallet'  And '$(MSBuildProjectName)' != 'Nethereum.WalletConnect'">
     <PackageReference Include="Newtonsoft.Json" Version="[11.0.2,14)" />
   </ItemGroup>
-  
+
    <ItemGroup Condition="'$(MSBuildProjectName)' == 'Nethereum.HdWallet' And ('$(TargetUnityAOT)' != 'true')">
     <PackageReference Include="Newtonsoft.Json" Version="[11.0.2,14)" />
   </ItemGroup>
@@ -83,7 +83,7 @@
     <DefineConstants>$(DefineConstants);PCL</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="System.Numerics" />
     <Reference Include="Microsoft.CSharp" />

--- a/buildConf/Frameworks.props
+++ b/buildConf/Frameworks.props
@@ -83,7 +83,7 @@
     <DefineConstants>$(DefineConstants);PCL</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472' ">
     <Reference Include="System" />
     <Reference Include="System.Numerics" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Nethereum.Fx.csproj
+++ b/src/Nethereum.Fx.csproj
@@ -27,6 +27,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Define LATEST_CRYPTOGRAPHY as we're using BouncyCastle.Cryptography -->
+    <DefineConstants>$(DefineConstants);LATEST_CRYPTOGRAPHY</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\FxOutput\Nethereum.Fx\</OutputPath>
   </PropertyGroup>
@@ -78,7 +83,7 @@
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
     <PackageReference Include="NBitcoin" Version="7.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="[11.0.2,14)" />
-    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.3.1,3.0)" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
     <PackageReference Include="System.Reactive" Version="4.1.3" />
   </ItemGroup>
 
@@ -329,8 +334,11 @@
 	<None Remove="Nethereum.Unity\**" />
 	<None Remove="Nethereum.Unity.Metamask\**" />
 	<None Remove="Nethereum.Metamask\**" />
-	<None Remove="Nethereum.Metamask.Blazor\**" />
+    <None Remove="Nethereum.Metamask.Blazor\**" />
     <None Remove="packages\**" />
+
+    <Compile Remove="Nethereum.Reown.AppKit.Blazor\**" />
+    <None Remove="Nethereum.Reown.AppKit.Blazor\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nethereum.Fx.csproj
+++ b/src/Nethereum.Fx.csproj
@@ -26,9 +26,9 @@
     <TargetFrameworks>net8.0;net5.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Define LATEST_CRYPTOGRAPHY as we're using BouncyCastle.Cryptography -->
-    <DefineConstants>$(DefineConstants);LATEST_CRYPTOGRAPHY</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+    <!-- Define LATEST_BOUNCYCASTLE as we're using BouncyCastle.Cryptography -->
+    <DefineConstants>$(DefineConstants);LATEST_BOUNCYCASTLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -77,13 +77,19 @@
 	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6.0.1,9)" />
 </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net8.0'">
+    <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
+  </ItemGroup>
 
 <ItemGroup>
     <PackageReference Include="ADRaffy.ENSNormalize" Version="0.1.5" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
     <PackageReference Include="NBitcoin" Version="7.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="[11.0.2,14)" />
-    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
     <PackageReference Include="System.Reactive" Version="4.1.3" />
   </ItemGroup>
 

--- a/src/Nethereum.Fx.csproj
+++ b/src/Nethereum.Fx.csproj
@@ -72,13 +72,13 @@
 	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6.0.1,9)" />
 </ItemGroup>
 
- 
+
 <ItemGroup>
     <PackageReference Include="ADRaffy.ENSNormalize" Version="0.1.5" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
     <PackageReference Include="NBitcoin" Version="7.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="[11.0.2,14)" />
-    <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.3.1,3.0)" />
     <PackageReference Include="System.Reactive" Version="4.1.3" />
   </ItemGroup>
 
@@ -97,7 +97,7 @@
     <Compile Remove="Nethereum.JsonRpc.UnixIpcClient\**" />
     <Compile Remove="Nethereum.StandardNonFungibleTokenERC721\**" />
     <Compile Remove="Nethereum.StandardTokenEIP20\**" />
-    
+
     <None Remove="Nethereum.BigInteger.N351\**" />
     <None Remove="Nethereum.ClassDiagrams\**" />
     <None Remove="Nethereum.ENS\**" />
@@ -106,7 +106,7 @@
     <Compile Remove="Nethereum.Hex\Properties\**;Nethereum.Hex\bin\**;Nethereum.Hex\obj\**" />
 
 
-  
+
 
     <None Remove="Nethereum.Generators.JavaScript\**" />
     <None Remove="Nethereum.Hex\Properties\**;Nethereum.Hex\bin\**;Nethereum.Hex\obj\**" />
@@ -120,7 +120,7 @@
 
     <None Remove="Nethereum.JsonRpc.WebSocketStreamingClient\obj\**" />
 
-   
+
     <None Remove="Nethereum.RPC\Properties\**;Nethereum.RPC\bin\**;Nethereum.RPC\obj\**" />
 
     <Compile Remove="Nethereum.Web3\Properties\**;Nethereum.Web3\bin\**;Nethereum.Web3\obj\**" />
@@ -233,14 +233,14 @@
 
 	  <Compile Remove="Nethereum.RPC.Extensions\Properties\**;Nethereum.RPC.Extensions\bin\**;Nethereum.RPC.Extensions\obj\**" />
 	  <None Remove="Nethereum.RPC.Extensions\Properties\**;Nethereum.RPC.Extensions\bin\**;Nethereum.RPC.Extensions\obj\**" />
-	  
+
       <Compile Remove="Nethereum.DataServices\Properties\**;Nethereum.DataServices\bin\**;Nethereum.DataServices\obj\**" />
 	  <None Remove="Nethereum.DataServices\Properties\**;Nethereum.DataServices\bin\**;Nethereum.DataServices\obj\**" />
-        
-	 
+
+
 
   </ItemGroup>
-  
+
   <ItemGroup>
 
     <Compile Remove="compiledlibraries\**" />
@@ -248,7 +248,7 @@
     <Compile Remove="Nethereum.Signer.AzureKeyVault\**" />
 
 	<Compile Remove="Nethereum.Signer.AWSKeyManagement\**" />
-	
+
 	  <Compile Remove="Nethereum.UI\**" />
 
 	<Compile Remove="Nethereum.Metamask\**" />
@@ -256,13 +256,13 @@
 	<Compile Remove="Nethereum.WalletConnect\**" />
 
 	<Compile Remove="Nethereum.Metamask.Blazor\**" />
-	  
+
     <Compile Remove="Nethereum.Signer.Ledger\**" />
 
     <Compile Remove="Nethereum.Signer.Trezor\**" />
 
 	<Compile Remove="Nethereum.Unity\**" />
-	  
+
 	<Compile Remove="Nethereum.Unity.Metamask\**" />
 
 	<None Remove="Nethereum.Mud.Contracts\**" />
@@ -276,7 +276,7 @@
 	<None Remove="Nethereum.Mud.Repositories.EntityFramework\**" />
 
 	<Compile Remove="Nethereum.Mud.Repositories.EntityFramework\**" />
-	  
+
 	<None Remove="Nethereum.Mud.Repositories.Postgres\**" />
 
 	<Compile Remove="Nethereum.Mud.Repositories.Postgres\**" />
@@ -319,8 +319,8 @@
 	<EmbeddedResource Remove="Nethereum.WalletConnect\**" />
 
     <None Remove="compiledlibraries\**" />
-  
-    
+
+
     <None Remove="Nethereum.GSN\**" />
     <None Remove="Nethereum.Signer.AzureKeyVault\**" />
 	<None Remove="Nethereum.Signer.AWSKeyManagement\**" />

--- a/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
+++ b/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
@@ -22,12 +22,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
-    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net472'">
+    <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' And '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetUnityNet461AOT)' != 'true'">

--- a/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
+++ b/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
-    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.3.1,3.0)" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">

--- a/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
+++ b/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' And '$(TargetFramework)' == 'net8.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
   </ItemGroup>
 

--- a/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
+++ b/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
-    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.3.1,2.0)" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.3.1,3.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">

--- a/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
+++ b/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
@@ -22,7 +22,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net472' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net8.0'">
     <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
   </ItemGroup>
 

--- a/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
+++ b/src/Nethereum.KeyStore/Nethereum.KeyStore.csproj
@@ -22,8 +22,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net472'">
-	  <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
+    <PackageReference Include="BouncyCastle.Cryptography" Version="[2.3.1,2.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+    <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetUnityNet461AOT)' != 'true'">

--- a/src/Nethereum.Signer/Crypto/ECDSASignature.cs
+++ b/src/Nethereum.Signer/Crypto/ECDSASignature.cs
@@ -91,7 +91,11 @@ namespace Nethereum.Signer.Crypto
             var seq = new DerSequenceGenerator(bos);
             seq.AddObject(new DerInteger(R));
             seq.AddObject(new DerInteger(S));
+
+#if !LATEST_CRYPTOGRAPHY
             seq.Close();
+#endif
+
             return bos.ToArray();
         }
     }

--- a/src/Nethereum.Signer/Crypto/ECDSASignature.cs
+++ b/src/Nethereum.Signer/Crypto/ECDSASignature.cs
@@ -92,7 +92,7 @@ namespace Nethereum.Signer.Crypto
             seq.AddObject(new DerInteger(R));
             seq.AddObject(new DerInteger(S));
 
-#if !LATEST_CRYPTOGRAPHY
+#if !LATEST_BOUNCYCASTLE
             seq.Close();
 #endif
 

--- a/src/Nethereum.Signer/Nethereum.Signer.csproj
+++ b/src/Nethereum.Signer/Nethereum.Signer.csproj
@@ -18,11 +18,20 @@
     <ProjectReference Include="..\Nethereum.RLP\Nethereum.RLP.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net472'">
-	  <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
+      <PackageReference Include="BouncyCastle.Cryptography" Version="[2.3.1,2.0)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetUnityNet461AOT)' != 'true' And '$(TargetUnityNet472AOT)' != 'true'">
+    <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
+        <DefineConstants>$(DefineConstants);LATEST_CRYPTOGRAPHY</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+        <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
+    </ItemGroup>
+
+
+    <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetUnityNet461AOT)' != 'true' And '$(TargetUnityNet472AOT)' != 'true'">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NethereumKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -52,7 +61,7 @@
       <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
 	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-	
+
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.1|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -100,7 +109,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-	
+
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -108,7 +117,7 @@
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
-	
+
   <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetUnityNet461AOT)' != 'true' And '$(TargetUnityNet472AOT)' != 'true'">
     <None Include="..\..\NethereumKey.snk" />
   </ItemGroup>

--- a/src/Nethereum.Signer/Nethereum.Signer.csproj
+++ b/src/Nethereum.Signer/Nethereum.Signer.csproj
@@ -18,11 +18,11 @@
     <ProjectReference Include="..\Nethereum.RLP\Nethereum.RLP.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net472' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net8.0'">
       <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' And '$(TargetFramework)' == 'net8.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0' ">
       <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
   </ItemGroup>
 

--- a/src/Nethereum.Signer/Nethereum.Signer.csproj
+++ b/src/Nethereum.Signer/Nethereum.Signer.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
-      <PackageReference Include="BouncyCastle.Cryptography" Version="[2.3.1,2.0)" />
+      <PackageReference Include="BouncyCastle.Cryptography" Version="[2.3.1,3.0)" />
   </ItemGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">

--- a/src/Nethereum.Signer/Nethereum.Signer.csproj
+++ b/src/Nethereum.Signer/Nethereum.Signer.csproj
@@ -26,7 +26,7 @@
       <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' And '$(TargetFramework)' == 'net8.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0' ">
       <DefineConstants>$(DefineConstants);LATEST_BOUNCYCASTLE</DefineConstants>
   </PropertyGroup>
 

--- a/src/Nethereum.Signer/Nethereum.Signer.csproj
+++ b/src/Nethereum.Signer/Nethereum.Signer.csproj
@@ -19,19 +19,18 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
-      <PackageReference Include="BouncyCastle.Cryptography" Version="[2.3.1,3.0)" />
+      <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
   </ItemGroup>
 
-    <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
-        <DefineConstants>$(DefineConstants);LATEST_CRYPTOGRAPHY</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
+      <DefineConstants>$(DefineConstants);LATEST_CRYPTOGRAPHY</DefineConstants>
+  </PropertyGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-        <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
-    </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+      <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
+  </ItemGroup>
 
-
-    <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetUnityNet461AOT)' != 'true' And '$(TargetUnityNet472AOT)' != 'true'">
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetUnityNet461AOT)' != 'true' And '$(TargetUnityNet472AOT)' != 'true'">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NethereumKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Nethereum.Signer/Nethereum.Signer.csproj
+++ b/src/Nethereum.Signer/Nethereum.Signer.csproj
@@ -18,17 +18,17 @@
     <ProjectReference Include="..\Nethereum.RLP\Nethereum.RLP.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net472'">
+      <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' And '$(TargetFramework)' == 'net8.0' ">
       <PackageReference Include="BouncyCastle.Cryptography" Version="[2.4.0,3.0)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetFramework)' != 'net451' And '$(TargetFramework)' != 'netstandard1.1' ">
-      <DefineConstants>$(DefineConstants);LATEST_CRYPTOGRAPHY</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' And '$(TargetFramework)' == 'net8.0' ">
+      <DefineConstants>$(DefineConstants);LATEST_BOUNCYCASTLE</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-      <PackageReference Include="Portable.BouncyCastle" Version="[1.8.2,2.0)" />
-  </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' And '$(TargetUnityNet461AOT)' != 'true' And '$(TargetUnityNet472AOT)' != 'true'">
     <SignAssembly>true</SignAssembly>

--- a/tests/Nethereum.Contracts.IntegrationTests/SmartContracts/Standards/ERC20Tests.cs
+++ b/tests/Nethereum.Contracts.IntegrationTests/SmartContracts/Standards/ERC20Tests.cs
@@ -80,7 +80,7 @@ namespace Nethereum.Contracts.IntegrationTests.SmartContracts.Standards
             var deploymentHandler = web3.Eth.GetContractDeploymentHandler<EIP20Deployment>();
             var receipt = await deploymentHandler.SendRequestAndWaitForReceiptAsync(deploymentContract).ConfigureAwait(false);
             var tokenService = web3.Eth.ERC20.GetContractService(receipt.ContractAddress);
-            
+
             var transfersEvent = tokenService.GetTransferEvent();
 
             var totalSupplyDeployed = await tokenService.TotalSupplyQueryAsync().ConfigureAwait(false);
@@ -152,7 +152,7 @@ namespace Nethereum.Contracts.IntegrationTests.SmartContracts.Standards
         public async void ERC20TokenBalances()
         {
             var web3 = _ethereumClientIntegrationFixture.GetInfuraWeb3(InfuraNetwork.Mainnet);
-            var tokens = await new TokenListService().LoadFromUrl(TokenListSources.UNISWAP).ConfigureAwait(false);
+            var tokens = await new TokenListService().LoadFromUrlAsync(TokenListSources.UNISWAP).ConfigureAwait(false);
             var tokensOwned = await web3.Eth.ERC20.GetAllTokenBalancesUsingMultiCallAsync(
                 new string[] { "0xBA12222222228d8Ba445958a75a0704d566BF2C8" }, tokens.Where(x => x.ChainId == 1),
                 BlockParameter.CreateLatest()).ConfigureAwait(false);
@@ -164,7 +164,7 @@ namespace Nethereum.Contracts.IntegrationTests.SmartContracts.Standards
         public async void ERC20TokenBalancesWithPricesExample()
         {
             var web3 = _ethereumClientIntegrationFixture.GetInfuraWeb3(InfuraNetwork.Mainnet);
-            var tokens = await new TokenListService().LoadFromUrl(TokenListSources.UNISWAP).ConfigureAwait(false);
+            var tokens = await new TokenListService().LoadFromUrlAsync(TokenListSources.UNISWAP).ConfigureAwait(false);
             var tokensOwned = await web3.Eth.ERC20.GetAllTokenBalancesUsingMultiCallAsync(
                 new string[] { "0xBA12222222228d8Ba445958a75a0704d566BF2C8" }, tokens.Where(x => x.ChainId == 1),
                 BlockParameter.CreateLatest()).ConfigureAwait(false);

--- a/tests/Nethereum.Mud.UnitTests/ResourceTests.cs
+++ b/tests/Nethereum.Mud.UnitTests/ResourceTests.cs
@@ -11,14 +11,14 @@ namespace Nethereum.Mud.UnitTests
             var result = ResourceEncoder.Encode(Resource.RESOURCE_TABLE, "store", "Tables");
             Assert.Equal("0x746273746f72650000000000000000005461626c657300000000000000000000", result.ToHex(true));
             var resource = ResourceEncoder.Decode(result);
-            Assert.True(resource.IsTable);
+            Assert.True(resource.IsTable());
             Assert.Equal("store", resource.Namespace);
             Assert.Equal("Tables", resource.Name);
 
             result = ResourceEncoder.Encode(Resource.RESOURCE_NAMESPACE, "store");
             Assert.Equal("0x6e7373746f726500000000000000000000000000000000000000000000000000", result.ToHex(true));
             resource = ResourceEncoder.Decode(result);
-            Assert.True(resource.IsNamespace);
+            Assert.True(resource.IsNamespace());
             Assert.Equal("store", resource.Namespace);
             Assert.Equal(String.Empty, resource.Name);
 
@@ -26,17 +26,17 @@ namespace Nethereum.Mud.UnitTests
             result = ResourceEncoder.Encode(Resource.RESOURCE_OFFCHAIN_TABLE, "world", "FunctionSignatur");
             Assert.Equal("0x6f74776f726c6400000000000000000046756e6374696f6e5369676e61747572", result.ToHex(true));
             resource = ResourceEncoder.Decode(result);
-            Assert.True(resource.IsOffchainTable);
+            Assert.True(resource.IsOffchainTable());
             Assert.Equal("world", resource.Namespace);
             Assert.Equal("FunctionSignatur", resource.Name);
 
             result = ResourceEncoder.Encode(Resource.RESOURCE_SYSTEM, "", "AccessManagement");
             Assert.Equal("0x737900000000000000000000000000004163636573734d616e6167656d656e74", result.ToHex(true));
             resource = ResourceEncoder.Decode(result);
-            Assert.True(resource.IsSystem);
+            Assert.True(resource.IsSystem());
             Assert.Equal(String.Empty, resource.Namespace);
             Assert.Equal("AccessManagement", resource.Name);
-            Assert.True(resource.IsRoot);
+            Assert.True(resource.IsRoot());
         }
     }
 }


### PR DESCRIPTION
Implements #1046 

Only use it for net6.0 and net8.0.

Chose 2.4.0 as the minimum version due to that one not having any (known) vulnerabilities unlike most previous versions and it requires a pragma that we might as well add now.

Also fixes several other compile issues.