### PR TITLE
Fix use of newer Bouncycastle library

### DIFF
--- a/src/Nethereum.Signer/Crypto/CompatibleDerSequenceGenerator.cs
+++ b/src/Nethereum.Signer/Crypto/CompatibleDerSequenceGenerator.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using Org.BouncyCastle.Asn1;
+
+namespace Nethereum.Signer.Crypto
+{
+    /// <summary>
+    /// Proxy that provides compatibility between difference Bouncy Castle versions.
+    /// </summary>
+    public class CompatibleDerSequenceGenerator : DerSequenceGenerator
+    {
+        public CompatibleDerSequenceGenerator(Stream outStream) : base(outStream)
+        {
+        }
+
+        public CompatibleDerSequenceGenerator(Stream outStream, int tagNo, bool isExplicit) : base(outStream, tagNo, isExplicit)
+        {
+        }
+
+        // The Close method is not available in the latest Bouncy Castle version
+        // It's part of the Finish method which is protected
+        public void Close()
+        {
+            #if LATEST_BOUNCYCASTLE
+            Finish();
+            #else
+            base.Close();
+            #endif
+        }
+    }
+}

--- a/src/Nethereum.Signer/Crypto/ECDSASignature.cs
+++ b/src/Nethereum.Signer/Crypto/ECDSASignature.cs
@@ -88,13 +88,12 @@ namespace Nethereum.Signer.Crypto
         {
             // Usually 70-72 bytes.
             var bos = new MemoryStream(72);
-            var seq = new DerSequenceGenerator(bos);
+            var seq = new CompatibleDerSequenceGenerator(bos);
+
             seq.AddObject(new DerInteger(R));
             seq.AddObject(new DerInteger(S));
 
-#if !LATEST_BOUNCYCASTLE
             seq.Close();
-#endif
 
             return bos.ToArray();
         }

--- a/tests/Nethereum.Signer.UnitTests/Nethereum.Signer.UnitTests.csproj
+++ b/tests/Nethereum.Signer.UnitTests/Nethereum.Signer.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Nethereum.Signer.UnitTests Class Library</Description>
     <Authors>Juan Blanco</Authors>
-	  <TargetFrameworks>net6.0</TargetFrameworks>
+	<TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>Nethereum.Signer.UnitTests</AssemblyName>
     <PackageId>Nethereum.Signer.UnitTests</PackageId>
   </PropertyGroup>


### PR DESCRIPTION
The previous implementation contained an issue, that might actually be part of Bouncycastle itself.
The `Close` method that was being called on the legacy versions was no longer part of the `DerSequenceGenerator` in the newer version.

After some additional digging it seems to have been replaced by a `Finish` method, however that method has the `protected` accessibility modifier and it thus not available by default.

To fix that I introduced a `CompatibleDerSequenceGenerator` class that doesn't do much except for adding back the `Close` method and calling on the protected `Finish` in case of the newer version.

To make sure this *Invalid DER Signature* exception was tested I've added additional frameworks to the *Nethereum.Signer.Unittests* project.