### PR TITLE
Add TryParse method to BigDecimal struct

### DIFF
--- a/src/Nethereum.Util/BigDecimal.cs
+++ b/src/Nethereum.Util/BigDecimal.cs
@@ -389,6 +389,22 @@ namespace Nethereum.Util
             return new BigDecimal(mantissa, exponent);
         }
 
+        public static bool TryParse(string? value, out BigDecimal result)
+        {
+            try
+            {
+                if (value == null) throw new ArgumentNullException(nameof(value));
+
+                result = Parse(value);
+                return true;
+            }
+            catch
+            {
+                result = default;
+                return false;
+            }
+        }
+
         /// <summary>
         ///     Returns the mantissa of value, aligned to the exponent of reference.
         ///     Assumes the exponent of value is larger than of value.

--- a/src/Nethereum.Util/Nethereum.Util.csproj
+++ b/src/Nethereum.Util/Nethereum.Util.csproj
@@ -8,6 +8,7 @@
     <AssemblyName>Nethereum.Util</AssemblyName>
     <PackageId>Nethereum.Util</PackageId>
     <PackageTags>Netherum;Ethereum;Blockchain</PackageTags>
+	<LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added TryParse method to the BigDecimal class to enable using the BigDecimal type as a query parameter in .NET minimal API endpoints.