### PR TITLE
Support NUGET_PACKAGES environment variable in Nethereum.Autogen.ContractApi

### DIFF
--- a/generators/Nethereum.Autogen.ContractApi/GeneratePackage.bat
+++ b/generators/Nethereum.Autogen.ContractApi/GeneratePackage.bat
@@ -3,7 +3,7 @@ echo.Clean
 dotnet clean -c release
 echo.Publishing
 cd ../Nethereum.Generator.Console
-dotnet publish -c release ---framework net8.0
+dotnet publish -c release --framework net8.0
 echo.Packing
 cd ../Nethereum.Autogen.ContractApi
 dotnet pack -c release

--- a/generators/Nethereum.Autogen.ContractApi/nuget/Nethereum.Autogen.ContractApi.nuspec
+++ b/generators/Nethereum.Autogen.ContractApi/nuget/Nethereum.Autogen.ContractApi.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Nethereum.Autogen.ContractApi</id>
-    <version>4.20.1</version>
+    <version>4.20.2</version>
     <authors>Juan Blanco, Dave Whiffin</authors>
     <owners>Juan Blanco</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/generators/Nethereum.Autogen.ContractApi/nuget/Nethereum.Autogen.ContractApi.targets
+++ b/generators/Nethereum.Autogen.ContractApi/nuget/Nethereum.Autogen.ContractApi.targets
@@ -4,14 +4,16 @@
     <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
   </PropertyGroup>
   
-   <PropertyGroup>
-    <NugetVersion>4.20.1</NugetVersion>
-  </PropertyGroup> 
+  <PropertyGroup>
+    <NugetVersion>4.20.2</NugetVersion>
+  </PropertyGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Message Condition = "$(NethereumGenerateCode) != 'false'" Importance="high" Text="Nethereum: Code generating dotnet files based on abi files in project and/or Nethereum.Generator.json" />
-    <Exec Condition = "$(IsWindows) == 'true' and $(NethereumGenerateCode) != 'false'" Command="dotnet &quot;%USERPROFILE%\.nuget\packages\nethereum.autogen.contractapi\$(NugetVersion)\tools\Nethereum.Generator.Console.dll&quot; generate from-project -p &quot;$(ProjectPath)&quot; -a &quot;$(TargetFileName)&quot;" />
-    <Exec Condition = "$(IsWindows) == ''  and $(NethereumGenerateCode) != 'false'" Command="dotnet ~/.nuget/packages/nethereum.autogen.contractapi/$(NugetVersion)/tools/Nethereum.Generator.Console.dll generate from-project -p &quot;$(ProjectPath)&quot; -a &quot;$(TargetFileName)&quot;" />
+    <Message Condition = "$(NethereumGenerateCode) != 'false'" Importance="high" Text="Nethereum: Code generating dotnet files based on abi files in project and/or Nethereum.Generator.json." />
+    <Exec Condition = "$(IsWindows) == 'true' and '$(NUGET_PACKAGES)' == '' and $(NethereumGenerateCode) != 'false'" Command="dotnet &quot;$(USERPROFILE)\.nuget\packages\nethereum.autogen.contractapi\$(NugetVersion)\tools\Nethereum.Generator.Console.dll&quot; generate from-project -p &quot;$(ProjectPath)&quot; -a &quot;$(TargetFileName)&quot;" />
+    <Exec Condition = "$(IsWindows) == 'true' and '$(NUGET_PACKAGES)' != '' and $(NethereumGenerateCode) != 'false'" Command="dotnet &quot;$(NUGET_PACKAGES)\nethereum.autogen.contractapi\$(NugetVersion)\tools\Nethereum.Generator.Console.dll&quot; generate from-project -p &quot;$(ProjectPath)&quot; -a &quot;$(TargetFileName)&quot;" />
+    <Exec Condition = "$(IsWindows) == '' and '$(NUGET_PACKAGES)' == '' and $(NethereumGenerateCode) != 'false'" Command="dotnet ~/.nuget/packages/nethereum.autogen.contractapi/$(NugetVersion)/tools/Nethereum.Generator.Console.dll generate from-project -p &quot;$(ProjectPath)&quot; -a &quot;$(TargetFileName)&quot;" />
+    <Exec Condition = "$(IsWindows) == '' and '$(NUGET_PACKAGES)' != '' and $(NethereumGenerateCode) != 'false'" Command="dotnet $(NUGET_PACKAGES)/nethereum.autogen.contractapi/$(NugetVersion)/tools/Nethereum.Generator.Console.dll generate from-project -p &quot;$(ProjectPath)&quot; -a &quot;$(TargetFileName)&quot;" />
     <Message Condition = "$(NethereumGenerateCode) != 'false'" Importance="high" Text="Nethereum: Code generation finished." />
   </Target>
 


### PR DESCRIPTION
Fix: Support NUGET_PACKAGES environment variable in code generation (Nethereum.Autogen.ContractApi)

Issue: Code generation fails during CI when NUGET_PACKAGES environment variable is used to customize NuGet package location, as the path is hardcoded to user profile locations.

Changes:
- Modified PreBuild target to check for NUGET_PACKAGES environment variable
- Use NUGET_PACKAGES path when set, fallback to default paths when not set
- Updated nuget version to 4.20.2

Fixes #1026