### PR TITLE
Add Docusaurus documentation skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,4 @@ This video provides an introduction on how to store and retrieve data from struc
 * Everyone in the Ethereum, Consensys and the blockchain community. 
 * Huge shout out to everyone developing all the different Ethereum implementations Geth, Parity, EthereumJ, EthCpp, ethereum-js (and every other utility around it), python (in the different shapes), ruby (digix guys), solidity, vyper, serpent, web3 implementations (web3js the first) and ethjs, web3j, etc, etc and last but not least the .Net Bitcoin implementation.
 * And many thanks to all you that keep helping and encouraging directly or indirectily.
+\n## Documentation\n\nTo build the documentation site:\n\n```bash\nnpm install\nnpm run start\n```\n

--- a/docs/advanced/blazor-dapp.md
+++ b/docs/advanced/blazor-dapp.md
@@ -1,0 +1,3 @@
+# Blazor dApp
+
+Guide to building a Blazor based dApp using Nethereum.

--- a/docs/advanced/hybrid-dapp.md
+++ b/docs/advanced/hybrid-dapp.md
@@ -1,0 +1,3 @@
+# Blazor Hybrid dApp
+
+Use Blazor Hybrid with Avalonia or MAUI for desktop experiences.

--- a/docs/advanced/log-processing.md
+++ b/docs/advanced/log-processing.md
@@ -1,0 +1,3 @@
+# Log Processing
+
+Use the blockchain processing libraries to index logs and events.

--- a/docs/advanced/mud-integration.md
+++ b/docs/advanced/mud-integration.md
@@ -1,0 +1,3 @@
+# MUD Integration
+
+Example architecture using entity component systems with backend storage.

--- a/docs/advanced/postgres-streaming.md
+++ b/docs/advanced/postgres-streaming.md
@@ -1,0 +1,3 @@
+# PostgreSQL Streaming
+
+Stream blockchain data into PostgreSQL for rich querying.

--- a/docs/advanced/unity-godot.md
+++ b/docs/advanced/unity-godot.md
@@ -1,0 +1,3 @@
+# Unity and Godot
+
+Integrate Ethereum games using Nethereum support for Unity and Godot.

--- a/docs/consoletests/index.md
+++ b/docs/consoletests/index.md
@@ -1,0 +1,3 @@
+# Console Tests
+
+Console test projects demonstrate advanced scenarios such as WalletConnect and MUD integration.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,3 @@
+# Contributing
+
+We welcome contributions. Submit pull requests via GitHub.

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -1,0 +1,3 @@
+# Core Libraries
+
+Overview of main Nethereum packages: ABI, RPC, Contracts, Signer and more.

--- a/docs/core/nethereum-abi.md
+++ b/docs/core/nethereum-abi.md
@@ -1,0 +1,7 @@
+# Nethereum.ABI
+
+The ABI library handles encoding and decoding of solidity types and data.
+
+```csharp
+var encoder = new ABIEncode();
+```

--- a/docs/core/nethereum-signer.md
+++ b/docs/core/nethereum-signer.md
@@ -1,0 +1,3 @@
+# Nethereum.Signer
+
+Provides transaction creation and signing utilities, including EIP-712.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,3 @@
+# Examples
+
+This section highlights common scenarios such as Uniswap integration and log streaming.

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -1,0 +1,3 @@
+# Architecture Overview
+
+Nethereum is composed of multiple libraries for RPC, signing, ABI handling, and contract integration.

--- a/docs/guides/code-generation.md
+++ b/docs/guides/code-generation.md
@@ -1,0 +1,7 @@
+# Code Generation
+
+Use ABI definitions to generate strongly typed services.
+
+```bash
+nethereum-codegen generate -a contract.abi -o Output
+```

--- a/docs/guides/multiformat.md
+++ b/docs/guides/multiformat.md
@@ -1,0 +1,3 @@
+# Multiformat
+
+Generated clients can target Blazor, console apps, and other frameworks.

--- a/docs/guides/vscode-extension.md
+++ b/docs/guides/vscode-extension.md
@@ -1,0 +1,3 @@
+# VSCode Extension
+
+Solidity support for VSCode helps with ABI code generation workflows.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,3 @@
+# Welcome to Nethereum
+
+Nethereum is the .NET integration library for interacting with Ethereum and EVM compatible blockchains. This site guides developers from first steps to building advanced dApps.

--- a/docs/journey/choosing-template.md
+++ b/docs/journey/choosing-template.md
@@ -1,0 +1,8 @@
+# Choosing a Template
+
+Nethereum provides project templates for Blazor, console apps, Unity and more.
+Install a template and create a new project:
+
+```bash
+dotnet new --install Nethereum.Templates
+```

--- a/docs/journey/getting-started.md
+++ b/docs/journey/getting-started.md
@@ -1,0 +1,21 @@
+# Getting Started
+
+## What is Nethereum?
+
+Nethereum simplifies Ethereum integration for .NET developers. It supports netstandard and modern .NET versions and works across desktop, mobile, and cloud environments.
+
+## Installation
+
+```bash
+# install core package
+dotnet add package Nethereum.Web3
+```
+
+## First transaction and contract query
+
+```csharp
+using Nethereum.Web3;
+
+var web3 = new Web3("https://rpc-url");
+var blockNumber = await web3.Eth.Blocks.GetBlockNumber.SendRequestAsync();
+```

--- a/docs/journey/typical-tasks.md
+++ b/docs/journey/typical-tasks.md
@@ -1,0 +1,11 @@
+# Typical Tasks
+
+- Transfer ETH
+- Call contract functions
+- Decode events
+- Estimate gas
+
+```csharp
+var receipt = await web3.Eth.GetEtherTransferService()
+    .TransferEtherAndWaitForReceiptAsync("0xaddress", 0.1m);
+```

--- a/docs/journey/using-playground.md
+++ b/docs/journey/using-playground.md
@@ -1,0 +1,4 @@
+# Using Playground
+
+The Nethereum Playground lets you run samples directly in the browser.
+Visit [playground.nethereum.com](https://playground.nethereum.com) to explore.

--- a/docs/playground/index.md
+++ b/docs/playground/index.md
@@ -1,0 +1,3 @@
+# Playground Examples
+
+Playground hosts interactive examples. Browse the source in the `playground` repository for more scenarios.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,3 @@
+# Release Notes
+
+See GitHub releases for version history.

--- a/docs/templates/index.md
+++ b/docs/templates/index.md
@@ -1,0 +1,3 @@
+# Project Templates
+
+Use templates to bootstrap Blazor, Unity, or Avalonia dApps.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,0 +1,32 @@
+module.exports = {
+  title: 'Nethereum',
+  tagline: 'Ethereum integration for .NET',
+  url: 'https://nethereum.com',
+  baseUrl: '/',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
+  favicon: 'img/favicon.ico',
+  organizationName: 'Nethereum',
+  projectName: 'Nethereum.Docusaurus',
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en'],
+  },
+  presets: [
+    [
+      '@docusaurus/preset-classic',
+      {
+        docs: {
+          path: 'docs',
+          routeBasePath: '/',
+          sidebarPath: require.resolve('./sidebars.js'),
+          editUrl: 'https://github.com/Nethereum/Nethereum.Docusaurus/edit/main/',
+        },
+        blog: false,
+        theme: {
+          customCss: require.resolve('./src/css/custom.css'),
+        },
+      },
+    ],
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nethereum-docs",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "docusaurus start",
+    "build": "docusaurus build",
+    "swizzle": "docusaurus swizzle" 
+  },
+  "dependencies": {
+    "@docusaurus/core": "^2.4.1",
+    "@docusaurus/preset-classic": "^2.4.1"
+  }
+}

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,0 +1,67 @@
+module.exports = {
+  docs: [
+    {
+      type: 'category',
+      label: 'Journey',
+      items: [
+        'journey/getting-started',
+        'journey/typical-tasks',
+        'journey/using-playground',
+        'journey/choosing-template'
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Playground',
+      items: ['playground/index'],
+    },
+    {
+      type: 'category',
+      label: 'Templates',
+      items: ['templates/index'],
+    },
+    {
+      type: 'category',
+      label: 'Examples',
+      items: ['examples/index'],
+    },
+    {
+      type: 'category',
+      label: 'Core',
+      items: [
+        'core/index',
+        'core/nethereum-abi',
+        'core/nethereum-signer'
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Guides',
+      items: [
+        'guides/code-generation',
+        'guides/multiformat',
+        'guides/vscode-extension',
+        'guides/architecture'
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Advanced',
+      items: [
+        'advanced/blazor-dapp',
+        'advanced/hybrid-dapp',
+        'advanced/unity-godot',
+        'advanced/mud-integration',
+        'advanced/log-processing',
+        'advanced/postgres-streaming'
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Console Tests',
+      items: ['consoletests/index'],
+    },
+    'contributing',
+    'releases'
+  ],
+};

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,0 +1,1 @@
+/* Custom styles */


### PR DESCRIPTION
## Summary
- add Docusaurus site config and sidebar
- write onboarding docs and advanced guides
- document code generation and core packages
- note instructions for running the docs in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: docusaurus not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9f2661c88325a369d596f5c95085