### PR TITLE
Support e-notation when parsing BigDecimal

### DIFF
--- a/src/Nethereum.Util/BigDecimal.cs
+++ b/src/Nethereum.Util/BigDecimal.cs
@@ -381,10 +381,19 @@ namespace Nethereum.Util
         {
             //todo culture format
             var decimalCharacter = ".";
-            var indexOfDecimal = value.IndexOf(".");
             var exponent = 0;
+
+            var indexOfExponent = value.LastIndexOf("E", StringComparison.OrdinalIgnoreCase);
+            if (indexOfExponent > 0)
+            {
+                exponent = int.Parse(value.Substring(indexOfExponent + 1));
+                value = value.Substring(0, indexOfExponent);
+            }
+
+            var indexOfDecimal = value.IndexOf(".");
             if (indexOfDecimal != -1)
-                exponent = (value.Length - (indexOfDecimal + 1)) * -1;
+                exponent += (value.Length - (indexOfDecimal + 1)) * -1;
+
             var mantissa = BigInteger.Parse(value.Replace(decimalCharacter, ""));
             return new BigDecimal(mantissa, exponent);
         }

--- a/tests/Nethereum.Util.UnitTests/BigDecimalTests.cs
+++ b/tests/Nethereum.Util.UnitTests/BigDecimalTests.cs
@@ -62,6 +62,18 @@ namespace Nethereum.Util.UnitTests
             Assert.Equal(value, BigDecimal.Parse(value).ToString());
         }
 
+        [Theory]
+        [InlineData("0.001", "1E-3")]
+        [InlineData("8000000", "80E+5")]
+        [InlineData("31542.2", "3.15422E4")]
+        [InlineData("0.000000516484", "5.16484e-7")]
+        [InlineData("5.16484", "0.000000516484e7")]
+        [InlineData("0", "0e7")]
+        public void ShouldParseENotation(string expected, string value)
+        {
+            Assert.Equal(expected, BigDecimal.Parse(value).ToString());
+        }
+
         [Fact]
         public void ShouldCastToDecimal()
         {


### PR DESCRIPTION
This adds support for parsing BigDecimals from strings in the E-notation (e.g. `5.38451E-7`)