### PR TITLE
Direct decoding of primitive integer types (avoid BigInteger allocations)

### DIFF
--- a/src/Nethereum.ABI/Decoders/IntTypeDecoder.cs
+++ b/src/Nethereum.ABI/Decoders/IntTypeDecoder.cs
@@ -4,6 +4,9 @@ using System.Numerics;
 using System.Reflection;
 using Nethereum.Hex.HexConvertors.Extensions;
 
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+using System.Buffers.Binary;
+#endif
 
 namespace Nethereum.ABI.Decoders
 {
@@ -22,20 +25,56 @@ namespace Nethereum.ABI.Decoders
 
         public override object Decode(byte[] encoded, Type type)
         {
+            object result = null;
+            int size = 32;
+
+            Byte expectedByteValue;
+            if (_signed && encoded.First() > 0) // Check that number is negative
+                expectedByteValue = 0xFF; // Expected leadings bytes for negative numbers
+            else
+                expectedByteValue = 0x00; // Expected leading bytes for positive numbers
+
             if (type == typeof(byte))
-                return DecodeByte(encoded);
+            {
+                result = DecodeByte(encoded);
+                size = 1;
+            }
 
             if (type == typeof(sbyte))
-                return DecodeSbyte(encoded);
+            {
+                var value = DecodeSbyte(encoded);
+                size = 1;
+                if (expectedByteValue == 0xFF && value >= 0
+                    || expectedByteValue == 0x00 && value < 0)
+                    throw new OverflowException();
+                result = value;
+            }
 
             if (type == typeof(short))
-                return DecodeShort(encoded);
+            {
+                var value = DecodeShort(encoded);
+                size = 2;
+                if (expectedByteValue == 0xFF && value >= 0
+                    || expectedByteValue == 0x00 && value < 0)
+                    throw new OverflowException();
+                result = value;
+            }
 
             if (type == typeof(ushort))
-                return DecodeUShort(encoded);
+            {
+                result = DecodeUShort(encoded);
+                size = 2;
+            }
 
             if (type == typeof(int))
-                return DecodeInt(encoded);
+            {
+                var value = DecodeInt(encoded);
+                size = 4;
+                if (expectedByteValue == 0xFF && value >= 0
+                    || expectedByteValue == 0x00 && value < 0)
+                    throw new OverflowException();
+                result = value;
+            }
 
             if (type.GetTypeInfo().IsEnum)
             {
@@ -44,25 +83,57 @@ namespace Nethereum.ABI.Decoders
             }
 
             if (type == typeof(uint))
-                return DecodeUInt(encoded);
+            {
+                result = DecodeUInt(encoded);
+                size = 4;
+            }
 
             if (type == typeof(long))
-                return DecodeLong(encoded);
+            {
+                var value = DecodeLong(encoded);
+                size = 8;
+                if (expectedByteValue == 0xFF && value >= 0
+                    || expectedByteValue == 0x00 && value < 0)
+                    throw new OverflowException();
+                result = value;
+            }
 
             if (type == typeof(ulong))
-                return DecodeULong(encoded);
+            {
+                result = DecodeULong(encoded);
+                size = 8;
+            }
 
 #if NET7_0_OR_GREATER
             if (type == typeof(UInt128))
-                return DecodeUInt128(encoded);
+            {
+                result = DecodeUInt128(encoded);
+                size = 16;
+            }
 
             if (type == typeof(Int128))
-                return DecodeInt128(encoded);
+            {
+                var value = DecodeInt128(encoded);
+                size = 16;
+                if (expectedByteValue == 0xFF && value >= 0
+                    || expectedByteValue == 0x00 && value < 0)
+                    throw new OverflowException();
+                result = value;
+            }
 #endif
-			if (type == typeof(BigInteger) || type == typeof(object))
+            if (type == typeof(BigInteger) || type == typeof(object))
                 return DecodeBigInteger(encoded);
 
-            throw new NotSupportedException(type + " is not a supported decoding type for IntType");
+            for (int i = 0; i < encoded.Length - size; i++)
+            {
+                if (encoded[i] != expectedByteValue)
+                    throw new OverflowException();
+            }
+
+            if (result is null)
+                throw new NotSupportedException(type + " is not a supported decoding type for IntType");
+            else
+                return result;
         }
 
         public BigInteger DecodeBigInteger(string hexString)
@@ -96,58 +167,76 @@ namespace Nethereum.ABI.Decoders
             return new BigInteger(encoded);
         }
 
-        public byte DecodeByte(byte[] encoded)
-        {
-            return (byte) DecodeBigInteger(encoded);
-        }
+        public byte DecodeByte(byte[] encoded) => encoded.Last();
 
-        public sbyte DecodeSbyte(byte[] encoded)
-        {
-            return (sbyte) DecodeBigInteger(encoded);
-        }
+        public sbyte DecodeSbyte(byte[] encoded) => (sbyte) encoded.Last();
 
         public short DecodeShort(byte[] encoded)
         {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+            return BinaryPrimitives.ReadInt16BigEndian(encoded[^2..]);
+#else
             return (short) DecodeBigInteger(encoded);
+#endif
         }
 
         public ushort DecodeUShort(byte[] encoded)
         {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+            return BinaryPrimitives.ReadUInt16BigEndian(encoded[^2..]);
+#else
             return (ushort) DecodeBigInteger(encoded);
+#endif
         }
 
         public int DecodeInt(byte[] encoded)
         {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+            return BinaryPrimitives.ReadInt32BigEndian(encoded[^4..]);
+#else
             return (int) DecodeBigInteger(encoded);
+#endif
         }
 
         public long DecodeLong(byte[] encoded)
         {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+            return BinaryPrimitives.ReadInt64BigEndian(encoded[^8..]);
+#else
             return (long) DecodeBigInteger(encoded);
+#endif
         }
 
         public uint DecodeUInt(byte[] encoded)
         {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+            return BinaryPrimitives.ReadUInt32BigEndian(encoded[^4..]);
+#else
             return (uint) DecodeBigInteger(encoded);
+#endif
         }
 
         public ulong DecodeULong(byte[] encoded)
         {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+            return BinaryPrimitives.ReadUInt64BigEndian(encoded[^8..]);
+#else
             return (ulong) DecodeBigInteger(encoded);
+#endif
         }
 
 #if NET7_0_OR_GREATER
         public UInt128 DecodeUInt128(byte[] encoded)
         {
-            return (UInt128) DecodeBigInteger(encoded);
+            return BinaryPrimitives.ReadUInt128BigEndian(encoded[^16..]);
         }
 
         public Int128 DecodeInt128(byte[] encoded)
         {
-            return (Int128) DecodeBigInteger(encoded);
+            return BinaryPrimitives.ReadInt128BigEndian(encoded[^16..]);
         }
 #endif
-		public override Type GetDefaultDecodingType()
+        public override Type GetDefaultDecodingType()
         {
             return typeof(BigInteger);
         }
@@ -162,7 +251,7 @@ namespace Nethereum.ABI.Decoders
 #if NET7_0_OR_GREATER
                    type == typeof(UInt128) || type == typeof(Int128) ||
 #endif
-				   type.GetTypeInfo().IsEnum;
+                   type.GetTypeInfo().IsEnum;
         }
 
         public override object DecodePacked(byte[] encoded, Type type)

--- a/tests/Nethereum.ABI.UnitTests/IntEncodingTests.cs
+++ b/tests/Nethereum.ABI.UnitTests/IntEncodingTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
@@ -137,77 +138,122 @@ namespace Nethereum.ABI.UnitTests
             Assert.Equal(TestEnum.Lion, decresult3);
         }
 
-
-        [Fact]
-        public virtual void ShouldEncodeDecodeInt()
+        [Theory]
+        [InlineData(int.MaxValue)]
+        [InlineData(int.MaxValue / 3)]
+        [InlineData(0)]
+        [InlineData(int.MinValue / 3)]
+        [InlineData(int.MinValue)]
+        public virtual void ShouldEncodeDecodeInt(int value)
         {
             var intType = new IntType("int");
-            var result = intType.Encode(int.MaxValue).ToHex();
+            var result = intType.Encode(value).ToHex();
             var intresult = intType.Decode<int>(result);
-            Assert.Equal(int.MaxValue, intresult);
+            Assert.Equal(value, intresult);
         }
 
-        [Fact]
-        public virtual void ShouldEncodeDecodeInt64()
+        [Theory]
+        [InlineData(long.MaxValue)]
+        [InlineData(long.MaxValue / 3)]
+        [InlineData(0)]
+        [InlineData(long.MinValue / 3)]
+        [InlineData(long.MinValue)]
+        public virtual void ShouldEncodeDecodeInt64(long value)
         {
             var intType = new IntType("int64");
-            var result = intType.Encode(long.MaxValue).ToHex();
+            var result = intType.Encode(value).ToHex();
             var intresult = intType.Decode<long>(result);
-            Assert.Equal(long.MaxValue, intresult);
+            Assert.Equal(value, intresult);
         }
 
-		[Fact]
-        public virtual void ShouldEncodeDecodeInt128()
+        [Theory]
+        [InlineData(long.MaxValue)]
+        [InlineData(long.MaxValue / 3)]
+        [InlineData(0)]
+        [InlineData(long.MinValue / 3)]
+        [InlineData(long.MinValue)]
+        public virtual void ShouldEncodeDecodeInt128(long value)
         {
+            Int128 value128 = (Int128) value;
             var intType = new IntType("int128");
-            var result = intType.Encode(Int128.MaxValue).ToHex();
+            var result = intType.Encode(value128).ToHex();
             var intresult = intType.Decode<Int128>(result);
-            Assert.Equal(Int128.MaxValue, intresult);
-		}
+            Assert.Equal(value128, intresult);
 
-        [Fact]
-        public virtual void ShouldEncodeDecodeUInt128()
+            value128 <<= 64;
+            result = intType.Encode(value128).ToHex();
+            intresult = intType.Decode<Int128>(result);
+            Assert.Equal(value128, intresult);
+        }
+
+        [Theory]
+        [InlineData(ulong.MaxValue)]
+        [InlineData(1)]
+        [InlineData(0)]
+        public virtual void ShouldEncodeDecodeUInt128(ulong value)
         {
+            UInt128 value128 = (UInt128) value;
             var intType = new IntType("uint128");
-            var result = intType.Encode(UInt128.MaxValue).ToHex();
+            var result = intType.Encode(value128).ToHex();
             var intresult = intType.Decode<UInt128>(result);
-            Assert.Equal(UInt128.MaxValue, intresult);
-		}
+            Assert.Equal(value128, intresult);
 
-		[Fact]
-        public virtual void ShouldEncodeDecodeSByte()
+            value128 <<= 64;
+            result = intType.Encode(value128).ToHex();
+            intresult = intType.Decode<UInt128>(result);
+            Assert.Equal(value128, intresult);
+        }
+
+        [Theory]
+        [InlineData(sbyte.MaxValue)]
+        [InlineData(sbyte.MaxValue / 3)]
+        [InlineData(0)]
+        [InlineData(sbyte.MinValue / 3)]
+        [InlineData(sbyte.MinValue)]
+        public virtual void ShouldEncodeDecodeSByte(sbyte value)
         {
             var intType = new IntType("int8");
-            var result = intType.Encode(sbyte.MaxValue).ToHex();
+            var result = intType.Encode(value).ToHex();
             var intresult = intType.Decode<sbyte>(result);
-            Assert.Equal(sbyte.MaxValue, intresult);
+            Assert.Equal(value, intresult);
         }
 
-        [Fact]
-        public virtual void ShouldEncodeDecodeShort()
+        [Theory]
+        [InlineData(short.MaxValue)]
+        [InlineData(short.MaxValue / 3)]
+        [InlineData(0)]
+        [InlineData(short.MinValue / 3)]
+        [InlineData(short.MinValue)]
+        public virtual void ShouldEncodeDecodeShort(short value)
         {
             var intType = new IntType("int16");
-            var result = intType.Encode(short.MaxValue).ToHex();
+            var result = intType.Encode(value).ToHex();
             var intresult = intType.Decode<short>(result);
-            Assert.Equal(short.MaxValue, intresult);
+            Assert.Equal(value, intresult);
         }
 
-        [Fact]
-        public virtual void ShouldEncodeDecodeUInt64()
+        [Theory]
+        [InlineData(ulong.MaxValue)]
+        [InlineData(1)]
+        [InlineData(0)]
+        public virtual void ShouldEncodeDecodeUInt64(ulong value)
         {
             var intType = new IntType("uint64");
-            var result = intType.Encode(ulong.MaxValue).ToHex();
+            var result = intType.Encode(value).ToHex();
             var intresult = intType.Decode<ulong>(result);
-            Assert.Equal(ulong.MaxValue, intresult);
+            Assert.Equal(value, intresult);
         }
 
-        [Fact]
-        public virtual void ShouldEncodeDecodeUShort()
+        [Theory]
+        [InlineData(ushort.MaxValue)]
+        [InlineData(1)]
+        [InlineData(0)]
+        public virtual void ShouldEncodeDecodeUShort(ushort value)
         {
             var intType = new IntType("uint16");
-            var result = intType.Encode(ushort.MaxValue).ToHex();
+            var result = intType.Encode(value).ToHex();
             var intresult = intType.Decode<ushort>(result);
-            Assert.Equal(ushort.MaxValue, intresult);
+            Assert.Equal(value, intresult);
         }
 
         [Fact]
@@ -269,6 +315,52 @@ namespace Nethereum.ABI.UnitTests
             var given = IntType.MAX_INT256_VALUE + 1;
             var ex = Assert.Throws<ArgumentOutOfRangeException>("value", () => intType.Encode(given));
             Assert.StartsWith("Signed SmartContract integer must not exceed maximum value for int256", ex.Message);
+        }
+
+        [Theory]
+        [InlineData(ulong.MaxValue, ulong.MinValue, "uint64")]
+        [InlineData(long.MaxValue, long.MinValue, "int64")]
+        [InlineData(uint.MaxValue, uint.MinValue, "uint32")]
+        [InlineData(int.MaxValue, int.MinValue, "int32")]
+        [InlineData(ushort.MaxValue, ushort.MinValue, "uint16")]
+        [InlineData(short.MaxValue, short.MinValue, "int16")]
+        [InlineData(byte.MaxValue, byte.MinValue, "uint8")]
+        [InlineData(sbyte.MaxValue, sbyte.MinValue, "int8")]
+        public virtual void ShouldThrowOverflowErrorWhenDecodingIntOutOfBoundaries(dynamic maxValue, dynamic minValue, string evmType)
+        {
+            var encodingIntType = new IntType("int256");
+            var decodingIntType = new IntType(evmType);
+            String result;
+
+            BigInteger givenMax = maxValue;
+            givenMax *= 3;
+
+            result = encodingIntType.Encode(givenMax).ToHex();
+            Assert.Throws<OverflowException>(() => decodingIntType.Decode(result, maxValue.GetType()));
+
+            BigInteger givenMin = minValue;
+            givenMin--;
+
+            result = encodingIntType.Encode(givenMin).ToHex();
+            Assert.Throws<OverflowException>(() => decodingIntType.Decode(result, minValue.GetType()));
+        }
+
+        [Fact]
+        public virtual void ShouldThrowOverflowErrorWhenDecodingInt128OutOfBoundaries()
+        {
+            var encodingIntType = new IntType("int256");
+            var decodingIntType = new IntType("int128");
+            String result;
+
+            BigInteger givenMax = Int128.MaxValue;
+            givenMax *= 3;
+            result = encodingIntType.Encode(givenMax).ToHex();
+            Assert.Throws<OverflowException>(() => decodingIntType.Decode(result, typeof(Int128)));
+
+            BigInteger givenMin = Int128.MinValue;
+            givenMin--;
+            result = encodingIntType.Encode(givenMin).ToHex();
+            Assert.Throws<OverflowException>(() => decodingIntType.Decode(result, typeof(Int128)));
         }
 
         [Fact]


### PR DESCRIPTION
This PR optimizes IntTypeDecoder by decoding primitive integer types directly from byte-array encoded instead of routing everything through DecodeBigInteger(byte[] encoded).