### PR TITLE
PrivacyPools: Align with 0xbow SDK v1.2.0 (safe keys, migration, artifact integrity)

### DIFF
--- a/src/Nethereum.PrivacyPools/AccountCommitment.cs
+++ b/src/Nethereum.PrivacyPools/AccountCommitment.cs
@@ -10,16 +10,18 @@ namespace Nethereum.PrivacyPools
         public BigInteger BlockNumber { get; set; }
         public string TransactionHash { get; set; } = "";
         public BigInteger Timestamp { get; set; }
+        public bool IsMigration { get; set; }
 
         public static AccountCommitment FromCommitment(PrivacyPoolCommitment commitment, int leafIndex,
-            BigInteger blockNumber, string transactionHash)
+            BigInteger blockNumber, string transactionHash, bool isMigration = false)
         {
             return new AccountCommitment
             {
                 Commitment = commitment,
                 LeafIndex = leafIndex,
                 BlockNumber = blockNumber,
-                TransactionHash = transactionHash
+                TransactionHash = transactionHash,
+                IsMigration = isMigration
             };
         }
     }
@@ -31,12 +33,13 @@ namespace Nethereum.PrivacyPools
         public List<AccountCommitment> Withdrawals { get; set; } = new List<AccountCommitment>();
         public bool IsRagequitted { get; set; }
         public BigInteger RagequitBlockNumber { get; set; }
+        public bool IsMigrated { get; set; }
 
         public AccountCommitment LatestCommitment =>
             Withdrawals.Count > 0 ? Withdrawals[Withdrawals.Count - 1] : Deposit;
 
         public BigInteger SpendableValue => LatestCommitment.Commitment.Value;
 
-        public bool IsSpendable => !IsRagequitted && SpendableValue > BigInteger.Zero;
+        public bool IsSpendable => !IsRagequitted && !IsMigrated && SpendableValue > BigInteger.Zero;
     }
 }

--- a/src/Nethereum.PrivacyPools/Circuits/CircuitArtifactHashes.cs
+++ b/src/Nethereum.PrivacyPools/Circuits/CircuitArtifactHashes.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Nethereum.PrivacyPools
+{
+    public static class CircuitArtifactHashes
+    {
+        // SHA-256 hex digests for Privacy Pools circuit artifacts.
+        // Matches the 0xbow SDK v1.2.0 artifact hash manifest, with compatibility
+        // aliases for the legacy Nethereum file names.
+        public static IReadOnlyDictionary<string, string> Default { get; } =
+            new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["commitment.wasm"] = "254d2130607182fd6fd1aee67971526b13cfe178c88e360da96dce92663828d8",
+            ["commitment.vkey"] = "7d48b4eb3dedc12fb774348287b587f0c18c3c7254cd60e9cf0f8b3636a570d8",
+            ["commitment_vk.json"] = "7d48b4eb3dedc12fb774348287b587f0c18c3c7254cd60e9cf0f8b3636a570d8",
+            ["commitment.zkey"] = "494ae92d64098fda2a5649690ddc5821fcd7449ca5fe8ef99ee7447544d7e1f3",
+            ["withdraw.wasm"] = "36cda22791def3d520a55c0fc808369cd5849532a75fab65686e666ed3d55c10",
+            ["withdrawal.wasm"] = "36cda22791def3d520a55c0fc808369cd5849532a75fab65686e666ed3d55c10",
+            ["withdraw.vkey"] = "666bd0983b20c1611543b04f7712e067fbe8cad69f07ada8a310837ff398d21e",
+            ["withdrawal_vk.json"] = "666bd0983b20c1611543b04f7712e067fbe8cad69f07ada8a310837ff398d21e",
+            ["withdraw.zkey"] = "2a893b42174c813566e5c40c715a8b90cd49fc4ecf384e3a6024158c3d6de677",
+            ["withdrawal.zkey"] = "2a893b42174c813566e5c40c715a8b90cd49fc4ecf384e3a6024158c3d6de677",
+        });
+    }
+}

--- a/src/Nethereum.PrivacyPools/Circuits/UrlCircuitArtifactSource.cs
+++ b/src/Nethereum.PrivacyPools/Circuits/UrlCircuitArtifactSource.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethereum.ZkProofs;
@@ -16,12 +19,15 @@ namespace Nethereum.PrivacyPools
         private readonly Dictionary<string, byte[]> _wasmCache = new Dictionary<string, byte[]>();
         private readonly Dictionary<string, byte[]> _zkeyCache = new Dictionary<string, byte[]>();
         private readonly Dictionary<string, string> _vkCache = new Dictionary<string, string>();
+        private readonly IReadOnlyDictionary<string, string> _expectedHashes;
 
-        public UrlCircuitArtifactSource(string baseUrl, string cacheDir = null, HttpClient httpClient = null)
+        public UrlCircuitArtifactSource(string baseUrl, string cacheDir = null,
+            HttpClient httpClient = null, IReadOnlyDictionary<string, string> expectedHashes = null)
         {
             _baseUrl = baseUrl.TrimEnd('/');
             _cacheDir = cacheDir;
             _httpClient = httpClient ?? new HttpClient();
+            _expectedHashes = expectedHashes ?? CircuitArtifactHashes.Default;
 
             if (_cacheDir != null)
                 Directory.CreateDirectory(_cacheDir);
@@ -29,33 +35,36 @@ namespace Nethereum.PrivacyPools
 
         public async Task<byte[]> GetWasmAsync(string circuitName, CancellationToken cancellationToken = default)
         {
-            if (_wasmCache.TryGetValue(circuitName, out var cached))
+            var cacheKey = NormalizeCacheKey(circuitName);
+            if (_wasmCache.TryGetValue(cacheKey, out var cached))
                 return cached;
 
-            var bytes = await FetchOrLoadCacheAsync($"{circuitName}.wasm", cancellationToken);
-            _wasmCache[circuitName] = bytes;
+            var bytes = await FetchOrLoadCacheAsync(GetArtifactFileNames(circuitName, ArtifactKind.Wasm), cancellationToken);
+            _wasmCache[cacheKey] = bytes;
             return bytes;
         }
 
         public async Task<byte[]> GetZkeyAsync(string circuitName, CancellationToken cancellationToken = default)
         {
-            if (_zkeyCache.TryGetValue(circuitName, out var cached))
+            var cacheKey = NormalizeCacheKey(circuitName);
+            if (_zkeyCache.TryGetValue(cacheKey, out var cached))
                 return cached;
 
-            var bytes = await FetchOrLoadCacheAsync($"{circuitName}.zkey", cancellationToken);
-            _zkeyCache[circuitName] = bytes;
+            var bytes = await FetchOrLoadCacheAsync(GetArtifactFileNames(circuitName, ArtifactKind.Zkey), cancellationToken);
+            _zkeyCache[cacheKey] = bytes;
             return bytes;
         }
 
         public string GetVerificationKeyJson(string circuitName)
         {
-            if (_vkCache.TryGetValue(circuitName, out var cached))
+            var cacheKey = NormalizeCacheKey(circuitName);
+            if (_vkCache.TryGetValue(cacheKey, out var cached))
                 return cached;
 
-            var task = FetchOrLoadCacheAsync($"{circuitName}_vk.json", CancellationToken.None);
-            task.Wait();
-            var json = System.Text.Encoding.UTF8.GetString(task.Result);
-            _vkCache[circuitName] = json;
+            var bytes = FetchOrLoadCacheAsync(GetArtifactFileNames(circuitName, ArtifactKind.VerificationKey),
+                CancellationToken.None).GetAwaiter().GetResult();
+            var json = System.Text.Encoding.UTF8.GetString(bytes);
+            _vkCache[cacheKey] = json;
             return json;
         }
 
@@ -67,11 +76,16 @@ namespace Nethereum.PrivacyPools
 
         public bool HasCircuit(string circuitName)
         {
-            if (_wasmCache.ContainsKey(circuitName))
+            var cacheKey = NormalizeCacheKey(circuitName);
+            if (_wasmCache.ContainsKey(cacheKey))
                 return true;
 
-            if (_cacheDir != null && File.Exists(Path.Combine(_cacheDir, $"{circuitName}.wasm")))
+            if (_cacheDir != null &&
+                GetArtifactFileNames(circuitName, ArtifactKind.Wasm)
+                    .Any(fileName => File.Exists(Path.Combine(_cacheDir, fileName))))
+            {
                 return true;
+            }
 
             return false;
         }
@@ -85,39 +99,119 @@ namespace Nethereum.PrivacyPools
             }
         }
 
-        private async Task<byte[]> FetchOrLoadCacheAsync(string fileName, CancellationToken cancellationToken)
+        private async Task<byte[]> FetchOrLoadCacheAsync(IEnumerable<string> fileNames, CancellationToken cancellationToken)
         {
             if (_cacheDir != null)
             {
-                var cachePath = Path.Combine(_cacheDir, fileName);
-                if (File.Exists(cachePath))
-                    return await File.ReadAllBytesAsync(cachePath
+                foreach (var fileName in fileNames)
+                {
+                    var cachePath = Path.Combine(_cacheDir, fileName);
+                    if (!File.Exists(cachePath))
+                        continue;
+
+                    var cached = await File.ReadAllBytesAsync(cachePath
 #if !NETSTANDARD2_0
                         , cancellationToken
 #endif
                     );
+                    VerifyIntegrity(cached, fileName);
+                    return cached;
+                }
             }
 
-            var url = $"{_baseUrl}/{fileName}";
-            var response = await _httpClient.GetAsync(url, cancellationToken);
-            response.EnsureSuccessStatusCode();
-            var bytes = await response.Content.ReadAsByteArrayAsync(
-#if !NETSTANDARD2_0
-                cancellationToken
-#endif
-            );
-
-            if (_cacheDir != null)
+            HttpRequestException lastNotFound = null;
+            foreach (var fileName in fileNames)
             {
-                var cachePath = Path.Combine(_cacheDir, fileName);
-                await File.WriteAllBytesAsync(cachePath, bytes
+                var url = $"{_baseUrl}/{fileName}";
+                using var response = await _httpClient.GetAsync(url, cancellationToken);
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    lastNotFound = new HttpRequestException($"Artifact not found: {url}");
+                    continue;
+                }
+
+                response.EnsureSuccessStatusCode();
+                var bytes = await response.Content.ReadAsByteArrayAsync(
 #if !NETSTANDARD2_0
-                    , cancellationToken
+                    cancellationToken
 #endif
                 );
+
+                VerifyIntegrity(bytes, fileName);
+
+                if (_cacheDir != null)
+                {
+                    var cachePath = Path.Combine(_cacheDir, fileName);
+                    await File.WriteAllBytesAsync(cachePath, bytes
+#if !NETSTANDARD2_0
+                        , cancellationToken
+#endif
+                    );
+                }
+
+                return bytes;
             }
 
-            return bytes;
+            if (lastNotFound != null)
+                throw lastNotFound;
+
+            throw new InvalidOperationException("No circuit artifact file names were provided.");
+        }
+
+        private void VerifyIntegrity(byte[] data, string fileName)
+        {
+            if (!_expectedHashes.TryGetValue(fileName, out var expectedHash))
+                throw new InvalidOperationException(
+                    $"No integrity hash registered for '{fileName}'. Refusing to load unverified artifact.");
+
+            using var sha = SHA256.Create();
+            var actual = BitConverter.ToString(sha.ComputeHash(data)).Replace("-", "").ToLowerInvariant();
+
+            if (actual != expectedHash.ToLowerInvariant())
+                throw new InvalidOperationException(
+                    $"Integrity check failed for '{fileName}'. Expected SHA-256: {expectedHash}, got: {actual}");
+        }
+
+        private static string NormalizeCacheKey(string circuitName)
+        {
+            return circuitName.Equals("withdraw", StringComparison.OrdinalIgnoreCase)
+                ? "withdrawal"
+                : circuitName.ToLowerInvariant();
+        }
+
+        private static string[] GetArtifactFileNames(string circuitName, ArtifactKind artifactKind)
+        {
+            if (circuitName.Equals("withdraw", StringComparison.OrdinalIgnoreCase) ||
+                circuitName.Equals("withdrawal", StringComparison.OrdinalIgnoreCase))
+            {
+                switch (artifactKind)
+                {
+                    case ArtifactKind.Wasm:
+                        return new[] { "withdraw.wasm", "withdrawal.wasm" };
+                    case ArtifactKind.Zkey:
+                        return new[] { "withdraw.zkey", "withdrawal.zkey" };
+                    default:
+                        return new[] { "withdraw.vkey", "withdrawal_vk.json" };
+                }
+            }
+
+            var normalized = circuitName.ToLowerInvariant();
+            switch (artifactKind)
+            {
+                case ArtifactKind.Wasm:
+                    return new[] { $"{normalized}.wasm" };
+                case ArtifactKind.Zkey:
+                    return new[] { $"{normalized}.zkey" };
+                default:
+                    return new[] { $"{normalized}.vkey", $"{normalized}_vk.json" };
+            }
+        }
+
+        private enum ArtifactKind
+        {
+            Wasm,
+            Zkey,
+            VerificationKey
         }
     }
 }

--- a/src/Nethereum.PrivacyPools/PrivacyPool.cs
+++ b/src/Nethereum.PrivacyPools/PrivacyPool.cs
@@ -12,6 +12,7 @@ namespace Nethereum.PrivacyPools
     public class PrivacyPool
     {
         public PrivacyPoolAccount Account { get; }
+        public PrivacyPoolAccount LegacyAccount { get; }
         public PrivacyPoolService Pool { get; }
         public PrivacyPoolProofVerifier Verifier { get; private set; }
 
@@ -29,17 +30,27 @@ namespace Nethereum.PrivacyPools
             PoolAddress = poolAddress;
 
             Account = new PrivacyPoolAccount(mnemonic, mnemonicPassword);
+            LegacyAccount = PrivacyPoolAccount.CreateLegacy(mnemonic, mnemonicPassword);
             Pool = new PrivacyPoolService(web3, entrypointAddress, poolAddress, commitmentStore);
         }
 
+        // Safe-key-only constructor. LegacyAccount will be null, so RecoverAccounts()
+        // will throw — use RecoverSafeAccounts() or supply a legacyAccount explicitly.
         public PrivacyPool(IWeb3 web3, string entrypointAddress, string poolAddress,
             PrivacyPoolAccount account, ICommitmentStore commitmentStore = null)
+            : this(web3, entrypointAddress, poolAddress, account, legacyAccount: null, commitmentStore)
+        {
+        }
+
+        public PrivacyPool(IWeb3 web3, string entrypointAddress, string poolAddress,
+            PrivacyPoolAccount account, PrivacyPoolAccount legacyAccount, ICommitmentStore commitmentStore = null)
         {
             Web3 = web3 ?? throw new ArgumentNullException(nameof(web3));
             EntrypointAddress = entrypointAddress;
             PoolAddress = poolAddress;
 
             Account = account ?? throw new ArgumentNullException(nameof(account));
+            LegacyAccount = legacyAccount;
             Pool = new PrivacyPoolService(web3, entrypointAddress, poolAddress, commitmentStore);
         }
 
@@ -61,6 +72,15 @@ namespace Nethereum.PrivacyPools
                 account, commitmentStore);
         }
 
+        public static PrivacyPool FromDeployment(IWeb3 web3, PrivacyPoolDeploymentResult deployment,
+            PrivacyPoolAccount account, PrivacyPoolAccount legacyAccount, ICommitmentStore commitmentStore = null)
+        {
+            return new PrivacyPool(web3,
+                deployment.Entrypoint.ContractAddress,
+                deployment.Pool.ContractAddress,
+                account, legacyAccount, commitmentStore);
+        }
+
         public async Task InitializeAsync()
         {
             await Pool.InitializeAsync();
@@ -74,11 +94,66 @@ namespace Nethereum.PrivacyPools
             IEnumerable<PoolLeafEventData> leafInserts,
             int maxConsecutiveMisses = 10)
         {
+            if (LegacyAccount == null)
+                throw new InvalidOperationException(
+                    "Migration-aware recovery requires a legacy account. " +
+                    "Construct with a mnemonic or supply a PrivacyPoolAccount.CreateLegacy(...) instance.");
+
+            return RecoverAccountsInternal(
+                deposits, withdrawals, ragequits, leafInserts, maxConsecutiveMisses);
+        }
+
+        public List<PoolAccount> RecoverSafeAccounts(
+            IEnumerable<PoolDepositEventData> deposits,
+            IEnumerable<PoolWithdrawalEventData> withdrawals,
+            IEnumerable<PoolRagequitEventData> ragequits,
+            IEnumerable<PoolLeafEventData> leafInserts,
+            int maxConsecutiveMisses = 10)
+        {
             var recovered = PrivacyPoolAccountRecovery.RecoverAccounts(
                 Account, Scope, deposits, withdrawals, ragequits, leafInserts, maxConsecutiveMisses);
+
             PoolAccounts.Clear();
             PoolAccounts.AddRange(recovered);
             return recovered;
+        }
+
+        private List<PoolAccount> RecoverAccountsInternal(
+            IEnumerable<PoolDepositEventData> deposits,
+            IEnumerable<PoolWithdrawalEventData> withdrawals,
+            IEnumerable<PoolRagequitEventData> ragequits,
+            IEnumerable<PoolLeafEventData> leafInserts,
+            int maxConsecutiveMisses)
+        {
+            var lookups = PrivacyPoolAccountRecovery.BuildLookups(deposits, withdrawals, ragequits, leafInserts);
+
+            var legacyRecovered = PrivacyPoolAccountRecovery.RecoverAccountsFromLookups(
+                LegacyAccount, Scope, lookups, maxConsecutiveMisses);
+
+            var migrated = PrivacyPoolAccountRecovery.DiscoverMigratedCommitments(
+                Account, Scope, legacyRecovered, lookups);
+
+            var safeRecovered = PrivacyPoolAccountRecovery.RecoverAccountsFromLookups(
+                Account, Scope, lookups, maxConsecutiveMisses, startIndex: migrated.Count);
+
+            var seen = new HashSet<BigInteger>();
+            var merged = new List<PoolAccount>();
+
+            foreach (var pa in legacyRecovered)
+                if (seen.Add(pa.Deposit.Commitment.CommitmentHash))
+                    merged.Add(pa);
+
+            foreach (var pa in migrated)
+                if (seen.Add(pa.Deposit.Commitment.CommitmentHash))
+                    merged.Add(pa);
+
+            foreach (var pa in safeRecovered)
+                if (seen.Add(pa.Deposit.Commitment.CommitmentHash))
+                    merged.Add(pa);
+
+            PoolAccounts.Clear();
+            PoolAccounts.AddRange(merged);
+            return merged;
         }
 
         public List<PoolAccount> GetSpendableAccounts()
@@ -125,15 +200,36 @@ namespace Nethereum.PrivacyPools
             PoseidonMerkleTree aspTree)
         {
             if (poolAccount == null) throw new ArgumentNullException(nameof(poolAccount));
+            if (poolAccount.LatestCommitment.LeafIndex < 0)
+                throw new InvalidOperationException(
+                    "Cannot withdraw: commitment leaf index is unknown. Re-sync with complete leaf events.");
             return await Pool.WithdrawDirectAsync(
                 poolAccount.LatestCommitment.Commitment,
                 poolAccount.LatestCommitment.LeafIndex,
                 withdrawnValue, recipient, proofProvider, stateTree, aspTree);
         }
 
-        public async Task<SyncResult> SyncFromChainAsync(
+        public Task<SyncResult> SyncFromChainAsync(
             BigInteger? fromBlock = null,
             PoseidonMerkleTree existingStateTree = null)
+        {
+            return SyncFromChainCoreAsync(
+                (d, w, r, l) => RecoverAccounts(d, w, r, l), fromBlock, existingStateTree);
+        }
+
+        public Task<SyncResult> SyncSafeFromChainAsync(
+            BigInteger? fromBlock = null,
+            PoseidonMerkleTree existingStateTree = null)
+        {
+            return SyncFromChainCoreAsync(
+                (d, w, r, l) => RecoverSafeAccounts(d, w, r, l), fromBlock, existingStateTree);
+        }
+
+        private async Task<SyncResult> SyncFromChainCoreAsync(
+            Func<IEnumerable<PoolDepositEventData>, IEnumerable<PoolWithdrawalEventData>,
+                IEnumerable<PoolRagequitEventData>, IEnumerable<PoolLeafEventData>, List<PoolAccount>> recover,
+            BigInteger? fromBlock,
+            PoseidonMerkleTree existingStateTree)
         {
             var repository = new InMemoryPrivacyPoolRepository();
             var stateTree = existingStateTree ?? new PoseidonMerkleTree();
@@ -149,7 +245,7 @@ namespace Nethereum.PrivacyPools
             var ragequits = await repository.GetRagequitsAsync();
             var leaves = await repository.GetLeavesAsync();
 
-            var recovered = RecoverAccounts(deposits, withdrawals, ragequits, leaves);
+            var recovered = recover(deposits, withdrawals, ragequits, leaves);
 
             var asp = CreateASPTreeService();
             asp.BuildFromDeposits(deposits);

--- a/src/Nethereum.PrivacyPools/PrivacyPoolAccount.cs
+++ b/src/Nethereum.PrivacyPools/PrivacyPoolAccount.cs
@@ -14,17 +14,27 @@ namespace Nethereum.PrivacyPools
         public BigInteger MasterSecret { get; }
 
         public PrivacyPoolAccount(string mnemonic, string password = "")
+            : this(mnemonic, password, useLegacyDerivation: false)
+        {
+        }
+
+        private PrivacyPoolAccount(string mnemonic, string password, bool useLegacyDerivation)
         {
             var wallet = new MinimalHDWallet(mnemonic, password);
 
             var key1Bytes = wallet.GetKeyFromPath("m/44'/60'/0'/0/0").GetPrivateKeyAsBytes();
             var key2Bytes = wallet.GetKeyFromPath("m/44'/60'/1'/0/0").GetPrivateKeyAsBytes();
 
-            var key1 = BytesToBigIntViaDouble(key1Bytes);
-            var key2 = BytesToBigIntViaDouble(key2Bytes);
+            var key1 = useLegacyDerivation ? BytesToBigIntViaDouble(key1Bytes) : BytesToBigInt(key1Bytes);
+            var key2 = useLegacyDerivation ? BytesToBigIntViaDouble(key2Bytes) : BytesToBigInt(key2Bytes);
 
             MasterNullifier = HasherT1.Hash(key1);
             MasterSecret = HasherT1.Hash(key2);
+        }
+
+        public static PrivacyPoolAccount CreateLegacy(string mnemonic, string password = "")
+        {
+            return new PrivacyPoolAccount(mnemonic, password, useLegacyDerivation: true);
         }
 
         public PrivacyPoolAccount(BigInteger masterNullifier, BigInteger masterSecret)
@@ -64,11 +74,14 @@ namespace Nethereum.PrivacyPools
             return PrivacyPoolCommitment.Create(value, label, nullifier, secret);
         }
 
-        // Replicates viem's bytesToNumber() behavior which converts 32-byte private keys
-        // through JavaScript's Number type (IEEE 754 double, ~53 bits mantissa), losing
-        // precision for values > 2^53. The 0xbow SDK uses bytesToNumber() in generateMasterKeys(),
-        // so we must match this lossy conversion for cross-compatibility.
-        // See: https://github.com/0xbow-io/privacy-pools-core/packages/sdk/src/crypto.ts
+        // Full 256-bit big-endian conversion matching viem's bytesToBigInt (SDK v1.2.0+).
+        public static BigInteger BytesToBigInt(byte[] bytes)
+        {
+            return new BigInteger(bytes, isUnsigned: true, isBigEndian: true);
+        }
+
+        // Replicates viem's bytesToNumber() which truncates to IEEE 754 double (~53-bit mantissa).
+        // Used by SDK v1.1.x and earlier; kept for backward compatibility with legacy deposits.
         public static BigInteger BytesToBigIntViaDouble(byte[] bytes)
         {
             double value = 0;

--- a/src/Nethereum.PrivacyPools/PrivacyPoolAccountRecovery.cs
+++ b/src/Nethereum.PrivacyPools/PrivacyPoolAccountRecovery.cs
@@ -6,6 +6,70 @@ namespace Nethereum.PrivacyPools
 {
     public static class PrivacyPoolAccountRecovery
     {
+        // Pre-built event lookups shared between RecoverAccounts and DiscoverMigratedCommitments
+        // to avoid iterating the same event collections twice.
+        internal class EventLookups
+        {
+            public Dictionary<BigInteger, PoolDepositEventData> DepositsByPrecommitment { get; set; }
+            public Dictionary<BigInteger, List<PoolWithdrawalEventData>> WithdrawalsByNullifier { get; set; }
+            public Dictionary<BigInteger, PoolWithdrawalEventData> WithdrawalsByNewCommitment { get; set; }
+            public Dictionary<BigInteger, PoolRagequitEventData> RagequitsByLabel { get; set; }
+            public Dictionary<BigInteger, int> LeafIndexByCommitment { get; set; }
+        }
+
+        internal static EventLookups BuildLookups(
+            IEnumerable<PoolDepositEventData> deposits,
+            IEnumerable<PoolWithdrawalEventData> withdrawals,
+            IEnumerable<PoolRagequitEventData> ragequits,
+            IEnumerable<PoolLeafEventData> leafInserts)
+        {
+            var lookups = new EventLookups
+            {
+                DepositsByPrecommitment = new Dictionary<BigInteger, PoolDepositEventData>(),
+                WithdrawalsByNullifier = new Dictionary<BigInteger, List<PoolWithdrawalEventData>>(),
+                WithdrawalsByNewCommitment = new Dictionary<BigInteger, PoolWithdrawalEventData>(),
+                RagequitsByLabel = new Dictionary<BigInteger, PoolRagequitEventData>(),
+                LeafIndexByCommitment = new Dictionary<BigInteger, int>()
+            };
+
+            foreach (var evt in deposits)
+            {
+                if (!lookups.DepositsByPrecommitment.TryGetValue(evt.PrecommitmentHash, out var existing) ||
+                    evt.BlockNumber < existing.BlockNumber)
+                {
+                    lookups.DepositsByPrecommitment[evt.PrecommitmentHash] = evt;
+                }
+            }
+
+            foreach (var evt in withdrawals)
+            {
+                if (!lookups.WithdrawalsByNullifier.ContainsKey(evt.SpentNullifier))
+                    lookups.WithdrawalsByNullifier[evt.SpentNullifier] = new List<PoolWithdrawalEventData>();
+                lookups.WithdrawalsByNullifier[evt.SpentNullifier].Add(evt);
+
+                if (!lookups.WithdrawalsByNewCommitment.TryGetValue(evt.NewCommitment, out var existing) ||
+                    evt.BlockNumber < existing.BlockNumber)
+                {
+                    lookups.WithdrawalsByNewCommitment[evt.NewCommitment] = evt;
+                }
+            }
+
+            // SDK v1.2.0 matches ragequits by label, not by commitment hash.
+            foreach (var evt in ragequits)
+            {
+                if (!lookups.RagequitsByLabel.TryGetValue(evt.Label, out var existing) ||
+                    evt.BlockNumber < existing.BlockNumber)
+                {
+                    lookups.RagequitsByLabel[evt.Label] = evt;
+                }
+            }
+
+            foreach (var evt in leafInserts)
+                lookups.LeafIndexByCommitment[evt.Leaf] = (int)evt.Index;
+
+            return lookups;
+        }
+
         public static List<PoolAccount> RecoverAccounts(
             PrivacyPoolAccount account,
             BigInteger scope,
@@ -13,37 +77,29 @@ namespace Nethereum.PrivacyPools
             IEnumerable<PoolWithdrawalEventData> withdrawals,
             IEnumerable<PoolRagequitEventData> ragequits,
             IEnumerable<PoolLeafEventData> leafInserts,
-            int maxConsecutiveMisses = 10)
+            int maxConsecutiveMisses = 10,
+            int startIndex = 0)
         {
-            var depositsByPrecommitment = new Dictionary<BigInteger, PoolDepositEventData>();
-            foreach (var evt in deposits)
-                depositsByPrecommitment[evt.PrecommitmentHash] = evt;
+            var lookups = BuildLookups(deposits, withdrawals, ragequits, leafInserts);
+            return RecoverAccountsFromLookups(account, scope, lookups, maxConsecutiveMisses, startIndex);
+        }
 
-            var withdrawalsByNullifier = new Dictionary<BigInteger, List<PoolWithdrawalEventData>>();
-            foreach (var evt in withdrawals)
-            {
-                if (!withdrawalsByNullifier.ContainsKey(evt.SpentNullifier))
-                    withdrawalsByNullifier[evt.SpentNullifier] = new List<PoolWithdrawalEventData>();
-                withdrawalsByNullifier[evt.SpentNullifier].Add(evt);
-            }
-
-            var ragequitsByCommitment = new Dictionary<BigInteger, PoolRagequitEventData>();
-            foreach (var evt in ragequits)
-                ragequitsByCommitment[evt.Commitment] = evt;
-
-            var leafIndexByCommitment = new Dictionary<BigInteger, int>();
-            foreach (var evt in leafInserts)
-                leafIndexByCommitment[evt.Leaf] = (int)evt.Index;
-
+        internal static List<PoolAccount> RecoverAccountsFromLookups(
+            PrivacyPoolAccount account,
+            BigInteger scope,
+            EventLookups lookups,
+            int maxConsecutiveMisses,
+            int startIndex = 0)
+        {
             var discovered = new List<PoolAccount>();
             int consecutiveMisses = 0;
 
-            for (BigInteger depositIndex = 0; consecutiveMisses < maxConsecutiveMisses; depositIndex++)
+            for (BigInteger depositIndex = startIndex; consecutiveMisses < maxConsecutiveMisses; depositIndex++)
             {
                 var (nullifier, secret) = account.CreateDepositSecrets(scope, depositIndex);
                 var precommitment = account.ComputePrecommitment(nullifier, secret);
 
-                if (!depositsByPrecommitment.TryGetValue(precommitment, out var depositData))
+                if (!lookups.DepositsByPrecommitment.TryGetValue(precommitment, out var depositData))
                 {
                     consecutiveMisses++;
                     continue;
@@ -54,8 +110,8 @@ namespace Nethereum.PrivacyPools
                 var commitment = PrivacyPoolCommitment.Create(
                     depositData.Value, depositData.Label, nullifier, secret);
 
-                int leafIndex = leafIndexByCommitment.ContainsKey(commitment.CommitmentHash)
-                    ? leafIndexByCommitment[commitment.CommitmentHash]
+                int leafIndex = lookups.LeafIndexByCommitment.ContainsKey(commitment.CommitmentHash)
+                    ? lookups.LeafIndexByCommitment[commitment.CommitmentHash]
                     : -1;
 
                 var poolAccount = new PoolAccount
@@ -65,9 +121,9 @@ namespace Nethereum.PrivacyPools
                         commitment, leafIndex, depositData.BlockNumber, depositData.TransactionHash)
                 };
 
-                RecoverWithdrawalChain(account, poolAccount, withdrawalsByNullifier, leafIndexByCommitment);
+                RecoverWithdrawalChain(account, poolAccount, lookups.WithdrawalsByNullifier, lookups.LeafIndexByCommitment);
 
-                if (ragequitsByCommitment.TryGetValue(commitment.CommitmentHash, out var ragequitData))
+                if (lookups.RagequitsByLabel.TryGetValue(poolAccount.Deposit.Commitment.Label, out var ragequitData))
                 {
                     poolAccount.IsRagequitted = true;
                     poolAccount.RagequitBlockNumber = ragequitData.BlockNumber;
@@ -85,19 +141,18 @@ namespace Nethereum.PrivacyPools
             Dictionary<BigInteger, List<PoolWithdrawalEventData>> withdrawalsByNullifier,
             Dictionary<BigInteger, int> leafIndexByCommitment)
         {
-            var current = poolAccount.Deposit;
-            var label = current.Commitment.Label;
+            var current = poolAccount.LatestCommitment;
+            var label = poolAccount.Deposit.Commitment.Label;
 
-            for (BigInteger childIndex = 0; ; childIndex++)
+            for (BigInteger childIndex = poolAccount.Withdrawals.Count; ; childIndex++)
             {
                 var nullifierHash = current.Commitment.NullifierHash;
 
-                if (!withdrawalsByNullifier.TryGetValue(nullifierHash, out var matchedWithdrawals))
+                if (!withdrawalsByNullifier.TryGetValue(nullifierHash, out var matchedWithdrawals) ||
+                    matchedWithdrawals.Count == 0)
                     break;
 
-                var withdrawal = matchedWithdrawals.FirstOrDefault();
-                if (withdrawal == null)
-                    break;
+                var withdrawal = matchedWithdrawals.First();
 
                 var (wNullifier, wSecret) = account.CreateWithdrawalSecrets(label, childIndex);
                 var newCommitment = PrivacyPoolCommitment.Create(
@@ -105,7 +160,14 @@ namespace Nethereum.PrivacyPools
                     label, wNullifier, wSecret);
 
                 if (newCommitment.CommitmentHash != withdrawal.NewCommitment)
-                    break;
+                {
+                    poolAccount.Withdrawals.Add(AccountCommitment.FromCommitment(
+                        newCommitment, -1, withdrawal.BlockNumber, withdrawal.TransactionHash,
+                        isMigration: true));
+                    poolAccount.IsMigrated = true;
+                    current = poolAccount.Withdrawals[poolAccount.Withdrawals.Count - 1];
+                    continue;
+                }
 
                 int leafIndex = leafIndexByCommitment.ContainsKey(newCommitment.CommitmentHash)
                     ? leafIndexByCommitment[newCommitment.CommitmentHash]
@@ -116,6 +178,76 @@ namespace Nethereum.PrivacyPools
 
                 current = poolAccount.Withdrawals[poolAccount.Withdrawals.Count - 1];
             }
+        }
+
+        // Finds legacy accounts whose last commitment was spent via a key-rotation withdrawal
+        // (migration from legacy to safe keys). Mirrors the TS SDK v1.2.0 migration discovery.
+        internal static List<PoolAccount> DiscoverMigratedCommitments(
+            PrivacyPoolAccount safeAccount,
+            BigInteger scope,
+            IEnumerable<PoolAccount> legacyAccounts,
+            EventLookups lookups)
+        {
+            var migrated = new List<PoolAccount>();
+
+            foreach (var legacy in legacyAccounts)
+            {
+                if (!legacy.IsMigrated)
+                    continue;
+
+                var migrationCommitment = legacy.Withdrawals.FirstOrDefault(w => w.IsMigration);
+                if (migrationCommitment == null)
+                    continue;
+
+                var label = legacy.Deposit.Commitment.Label;
+                var remainingValue = migrationCommitment.Commitment.Value;
+                var (nullifier, secret) = safeAccount.CreateWithdrawalSecrets(label, BigInteger.Zero);
+                var commitment = PrivacyPoolCommitment.Create(remainingValue, label, nullifier, secret);
+
+                if (!lookups.WithdrawalsByNewCommitment.TryGetValue(commitment.CommitmentHash, out var spendingWithdrawal))
+                    continue;
+
+                int leafIndex = lookups.LeafIndexByCommitment.ContainsKey(commitment.CommitmentHash)
+                    ? lookups.LeafIndexByCommitment[commitment.CommitmentHash]
+                    : -1;
+
+                var poolAccount = new PoolAccount
+                {
+                    Scope = scope,
+                    Deposit = AccountCommitment.FromCommitment(
+                        commitment, leafIndex, spendingWithdrawal.BlockNumber, spendingWithdrawal.TransactionHash)
+                };
+
+                // Reserve withdrawal index 0 for the migration itself so subsequent
+                // safe-key withdrawals derive the same child indices as the v1.2.0 SDK.
+                poolAccount.Withdrawals.Add(AccountCommitment.FromCommitment(
+                    commitment, leafIndex, spendingWithdrawal.BlockNumber, spendingWithdrawal.TransactionHash));
+
+                RecoverWithdrawalChain(safeAccount, poolAccount, lookups.WithdrawalsByNullifier, lookups.LeafIndexByCommitment);
+
+                if (lookups.RagequitsByLabel.TryGetValue(label, out var ragequitData))
+                {
+                    poolAccount.IsRagequitted = true;
+                    poolAccount.RagequitBlockNumber = ragequitData.BlockNumber;
+                }
+
+                migrated.Add(poolAccount);
+            }
+
+            return migrated;
+        }
+
+        public static List<PoolAccount> DiscoverMigratedCommitments(
+            PrivacyPoolAccount safeAccount,
+            BigInteger scope,
+            IEnumerable<PoolAccount> legacyAccounts,
+            IEnumerable<PoolWithdrawalEventData> withdrawals,
+            IEnumerable<PoolLeafEventData> leafInserts,
+            IEnumerable<PoolRagequitEventData> ragequits)
+        {
+            var lookups = BuildLookups(
+                new List<PoolDepositEventData>(), withdrawals, ragequits, leafInserts);
+            return DiscoverMigratedCommitments(safeAccount, scope, legacyAccounts, lookups);
         }
 
         public static List<PoolAccount> GetSpendable(IEnumerable<PoolAccount> accounts)

--- a/src/Nethereum.PrivacyPools/README.md
+++ b/src/Nethereum.PrivacyPools/README.md
@@ -12,9 +12,18 @@ Derive deterministic master keys from a BIP-39 mnemonic. The same mnemonic alway
 var account = new PrivacyPoolAccount(mnemonic);
 // account.MasterNullifier — derived from m/44'/60'/0'/0/0
 // account.MasterSecret    — derived from m/44'/60'/1'/0/0
+
+var legacyAccount = PrivacyPoolAccount.CreateLegacy(mnemonic);
+// Use only when recovering deposits created by older SDKs that derived
+// master keys via JavaScript's lossy bytesToNumber() path.
+
+var pp = PrivacyPool.FromDeployment(web3, deployment, account, legacyAccount);
+// Pass both accounts when you want mnemonic-equivalent recovery without
+// constructing PrivacyPool directly from the mnemonic.
 ```
 
-<!-- Verified: AccountTests.CreateAccount_FromMnemonic_DerivesMasterKeys -->
+<!-- Verified: AccountTests.Legacy_CreateAccount_FromMnemonic_DerivesMasterKeys -->
+<!-- Verified: AccountTests.Safe_CreateAccount_FromMnemonic_DerivesMasterKeys -->
 
 ### Deposit with Deterministic Secrets
 
@@ -60,7 +69,15 @@ await pp.InitializeAsync();
 
 var recovered = pp.RecoverAccounts(deposits, withdrawals, ragequits, leaves);
 var spendable = pp.GetSpendableAccounts();
-// Each PoolAccount tracks: Deposit, Withdrawals, SpendableValue, IsRagequitted
+// Each PoolAccount tracks: Deposit, Withdrawals, SpendableValue,
+// IsRagequitted, and IsMigrated
+
+var safeOnly = PrivacyPool.FromDeployment(web3, deployment, new PrivacyPoolAccount(mnemonic));
+await safeOnly.InitializeAsync();
+var safeRecovered = safeOnly.RecoverSafeAccounts(deposits, withdrawals, ragequits, leaves);
+// RecoverSafeAccounts intentionally scans only v1.2.0 safe-key deposits.
+// RecoverAccounts requires a mnemonic or an explicit legacy companion account
+// so migrated funds are not skipped.
 ```
 
 <!-- Verified: PrivacyPoolIntegrationTests.FullJourney_Deposit_Process_Recover_Ragequit -->
@@ -176,13 +193,13 @@ if (source.HasCircuit("commitment"))
 
 ### Download Circuit Artifacts from URL
 
-Alternatively, fetch circuit artifacts from a remote URL with automatic local caching via `UrlCircuitArtifactSource`.
+Alternatively, fetch circuit artifacts from a remote URL with automatic local caching via `UrlCircuitArtifactSource`. The built-in v1.2.0 artifact hash manifest is applied by default, so every downloaded artifact is integrity-checked before use.
 
 ```csharp
 var source = new UrlCircuitArtifactSource(
     "https://example.com/circuits/v1",
     cacheDir: "./circuit-cache");
-await source.InitializeAsync("commitment", "withdrawal");
+await source.InitializeAsync("commitment", "withdraw");
 
 var proofProvider = new PrivacyPoolProofProvider(new SnarkjsProofProvider(), source);
 ```
@@ -256,6 +273,10 @@ var pp = PrivacyPool.FromDeployment(web3, deployment, mnemonic);
 await pp.InitializeAsync();
 
 var sync = await pp.SyncFromChainAsync();
+var safeOnly = PrivacyPool.FromDeployment(web3, deployment, new PrivacyPoolAccount(mnemonic));
+await safeOnly.InitializeAsync();
+var safeSync = await safeOnly.SyncSafeFromChainAsync();
+// Safe-only sync skips legacy/migration recovery by design.
 // sync.PoolAccounts — recovered accounts with spendable balances
 // sync.StateTree — Merkle tree of all commitments
 // sync.ASPTree — ASP tree built from deposit labels
@@ -474,7 +495,7 @@ The C# and TypeScript implementations produce identical outputs for the same inp
 - **Unit tests** (`CrossCompatibilityTests`) — hardcoded value matching for master keys, deposit/withdrawal secrets, commitment hashes, and context hashes against the JavaScript SDK
 - **E2E cross-SDK tests** (`CrossSdkTests`) — deposits made by the 0xbow TypeScript SDK are withdrawn/ragequitted by Nethereum, and vice versa, on a shared Geth dev chain with real Groth16 proof generation and on-chain verification. Covers both native ETH and ERC20 token flows
 
-One key detail: the TypeScript SDK converts private key bytes to BigInteger by first converting to a JavaScript `Number` (IEEE 754 double), which loses precision for values > 2^53. The C# implementation replicates this via `PrivacyPoolAccount.BytesToBigIntViaDouble` to ensure identical master key derivation.
+As of SDK v1.2.0, the TypeScript SDK derives master keys with `bytesToBigInt`, which matches `new PrivacyPoolAccount(mnemonic)` in C#. Older deposits created before that change used JavaScript's lossy `bytesToNumber()` path; Nethereum preserves compatibility for those historical accounts via `PrivacyPoolAccount.CreateLegacy(...)` and migration-aware recovery.
 
 ## Dependencies
 

--- a/tests/Nethereum.PrivacyPools.Circuits.Tests/PrivacyPoolIntegrationTests.cs
+++ b/tests/Nethereum.PrivacyPools.Circuits.Tests/PrivacyPoolIntegrationTests.cs
@@ -139,6 +139,31 @@ namespace Nethereum.PrivacyPools.Circuits.Tests
 
         [Fact]
         [Trait("Category", "E2E-Integration")]
+        public async Task SafeOnlySyncFromChain_RecoversSafeDeposits()
+        {
+            var pp = PrivacyPool.FromDeployment(_web3, _deployment, TEST_MNEMONIC);
+            await pp.InitializeAsync();
+
+            var depositValue = Web3.Web3.Convert.ToWei(1);
+            var depositResult = await pp.DepositAsync(depositValue, depositIndex: 0);
+            Assert.False(depositResult.Receipt.HasErrors());
+
+            var safeOnly = PrivacyPool.FromDeployment(
+                _web3,
+                _deployment,
+                new PrivacyPoolAccount(TEST_MNEMONIC));
+            await safeOnly.InitializeAsync();
+
+            var sync = await safeOnly.SyncSafeFromChainAsync();
+
+            var recovered = Assert.Single(sync.PoolAccounts);
+            Assert.Equal(depositResult.Commitment.CommitmentHash, recovered.Deposit.Commitment.CommitmentHash);
+            Assert.Equal(depositValue, recovered.SpendableValue);
+            Assert.True(recovered.IsSpendable);
+        }
+
+        [Fact]
+        [Trait("Category", "E2E-Integration")]
         [NethereumDocExample(DocSection.Protocols, "event-processing", "Process events and recover multiple accounts")]
         public async Task MultipleDeposits_ProcessAndRecover()
         {

--- a/tests/Nethereum.PrivacyPools.CrossSdk.Tests/CrossSdkTests.cs
+++ b/tests/Nethereum.PrivacyPools.CrossSdk.Tests/CrossSdkTests.cs
@@ -450,6 +450,214 @@ namespace Nethereum.PrivacyPools.CrossSdk.Tests
             _output.WriteLine("Nethereum ERC20 deposit → TS ragequit: SUCCESS");
         }
 
+        [Fact]
+        [Trait("Category", "CrossSdk")]
+        public async Task Safe_TsSdkDeposit_MatchesNethereumSafeKeys()
+        {
+            // TS SDK v1.2.0 deposit.mjs now uses bytesToBigInt (safe keys)
+            var depositResult = await RunNodeScript("deposit.mjs", new
+            {
+                rpcUrl = GETH_RPC_URL,
+                chainId = GETH_CHAIN_ID,
+                entrypointAddress = _deployment.Entrypoint.ContractAddress,
+                poolAddress = _deployment.Pool.ContractAddress,
+                privateKey = OWNER_PRIVATE_KEY,
+                mnemonic = TEST_MNEMONIC,
+                depositIndex = 20,
+                valueWei = Web3.Web3.Convert.ToWei(1).ToString(),
+                scope = _scope.ToString()
+            });
+
+            var tsMasterNullifier = BigInteger.Parse(depositResult["masterNullifier"]!.ToString());
+            var tsMasterSecret = BigInteger.Parse(depositResult["masterSecret"]!.ToString());
+
+            // Nethereum safe account (default constructor) should match TS SDK v1.2.0
+            var safeAccount = new PrivacyPoolAccount(TEST_MNEMONIC);
+            Assert.Equal(safeAccount.MasterNullifier, tsMasterNullifier);
+            Assert.Equal(safeAccount.MasterSecret, tsMasterSecret);
+
+            var tsCommitmentHash = BigInteger.Parse(depositResult["commitmentHash"]!.ToString());
+            var tsNullifier = BigInteger.Parse(depositResult["nullifier"]!.ToString());
+            var tsSecret = BigInteger.Parse(depositResult["secret"]!.ToString());
+            var tsLabel = BigInteger.Parse(depositResult["label"]!.ToString());
+            var depositValue = Web3.Web3.Convert.ToWei(1);
+
+            var nethCommitment = PrivacyPoolCommitment.Create(depositValue, tsLabel, tsNullifier, tsSecret);
+            Assert.Equal(tsCommitmentHash, nethCommitment.CommitmentHash);
+            _output.WriteLine("Safe keys: TS SDK v1.2.0 deposit matches Nethereum safe derivation");
+        }
+
+        [Fact]
+        [Trait("Category", "CrossSdk")]
+        public async Task Legacy_TsSdkDeposit_MatchesNethereumLegacyKeys()
+        {
+            // Legacy deposit script uses bytesToNumber (53-bit lossy)
+            var depositResult = await RunNodeScript("deposit-legacy.mjs", new
+            {
+                rpcUrl = GETH_RPC_URL,
+                chainId = GETH_CHAIN_ID,
+                entrypointAddress = _deployment.Entrypoint.ContractAddress,
+                poolAddress = _deployment.Pool.ContractAddress,
+                privateKey = OWNER_PRIVATE_KEY,
+                mnemonic = TEST_MNEMONIC,
+                depositIndex = 21,
+                valueWei = Web3.Web3.Convert.ToWei(1).ToString(),
+                scope = _scope.ToString()
+            });
+
+            var tsMasterNullifier = BigInteger.Parse(depositResult["masterNullifier"]!.ToString());
+            var tsMasterSecret = BigInteger.Parse(depositResult["masterSecret"]!.ToString());
+
+            // Nethereum legacy account should match TS SDK legacy derivation
+            var legacyAccount = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
+            Assert.Equal(legacyAccount.MasterNullifier, tsMasterNullifier);
+            Assert.Equal(legacyAccount.MasterSecret, tsMasterSecret);
+
+            var tsCommitmentHash = BigInteger.Parse(depositResult["commitmentHash"]!.ToString());
+            var tsNullifier = BigInteger.Parse(depositResult["nullifier"]!.ToString());
+            var tsSecret = BigInteger.Parse(depositResult["secret"]!.ToString());
+            var tsLabel = BigInteger.Parse(depositResult["label"]!.ToString());
+            var depositValue = Web3.Web3.Convert.ToWei(1);
+
+            var nethCommitment = PrivacyPoolCommitment.Create(depositValue, tsLabel, tsNullifier, tsSecret);
+            Assert.Equal(tsCommitmentHash, nethCommitment.CommitmentHash);
+            _output.WriteLine("Legacy keys: TS SDK legacy deposit matches Nethereum legacy derivation");
+        }
+
+        [Fact]
+        [Trait("Category", "CrossSdk")]
+        public async Task Legacy_TsSdkMigrationChain_NethereumRecoversSafeSpendableAccount()
+        {
+            var depositValue = Web3.Web3.Convert.ToWei(1);
+            var postMigrationValue = depositValue / 2;
+
+            var legacyDeposit = await RunNodeScript("deposit-legacy.mjs", new
+            {
+                rpcUrl = GETH_RPC_URL,
+                chainId = GETH_CHAIN_ID,
+                entrypointAddress = _deployment.Entrypoint.ContractAddress,
+                poolAddress = _deployment.Pool.ContractAddress,
+                privateKey = OWNER_PRIVATE_KEY,
+                mnemonic = TEST_MNEMONIC,
+                depositIndex = 30,
+                valueWei = depositValue.ToString(),
+                scope = _scope.ToString()
+            });
+
+            var legacyCommitmentHash = BigInteger.Parse(legacyDeposit["commitmentHash"]!.ToString());
+            var legacyLabel = BigInteger.Parse(legacyDeposit["label"]!.ToString());
+            var legacyNullifier = legacyDeposit["nullifier"]!.ToString();
+            var legacySecret = legacyDeposit["secret"]!.ToString();
+            _output.WriteLine($"Legacy TS deposit: commitment={legacyCommitmentHash}, label={legacyLabel}");
+
+            var aspTree = new PoseidonMerkleTree();
+            aspTree.InsertCommitment(legacyLabel);
+            var aspRoot = aspTree.RootAsBigInteger;
+
+            var aspReceipt = await _deployment.Entrypoint.UpdateRootRequestAndWaitForReceiptAsync(
+                aspRoot, "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3okuzefo5ij6neu");
+            Assert.False(aspReceipt.HasErrors());
+
+            var stateTree = new PoseidonMerkleTree();
+            stateTree.InsertCommitment(legacyCommitmentHash);
+            Assert.Equal(await _deployment.Pool.CurrentRootQueryAsync(), stateTree.RootAsBigInteger);
+
+            var migrationResult = await RunNodeScript("withdraw.mjs", new
+            {
+                rpcUrl = GETH_RPC_URL,
+                chainId = GETH_CHAIN_ID,
+                entrypointAddress = _deployment.Entrypoint.ContractAddress,
+                poolAddress = _deployment.Pool.ContractAddress,
+                privateKey = OWNER_PRIVATE_KEY,
+                artifactsDir = _artifactsDir.Replace("\\", "/"),
+                mnemonic = TEST_MNEMONIC,
+                scope = _scope.ToString(),
+                existingValue = depositValue.ToString(),
+                existingLabel = legacyLabel.ToString(),
+                existingNullifier = legacyNullifier,
+                existingSecret = legacySecret,
+                stateLeaves = new[] { legacyCommitmentHash.ToString() },
+                stateLeafIndex = "0",
+                aspLeaves = new[] { legacyLabel.ToString() },
+                aspLeafIndex = "0",
+                withdrawnValue = BigInteger.Zero.ToString(),
+                recipientAddress = _account.Address,
+                relayerAddress = _account.Address,
+                relayFeeBps = "0",
+                childIndex = "0"
+            });
+
+            Assert.True(migrationResult["success"]!.Value<bool>());
+            var migratedCommitmentHash = BigInteger.Parse(migrationResult["newCommitmentHash"]!.ToString());
+            _output.WriteLine($"TS migration commitment: {migratedCommitmentHash}");
+
+            stateTree.InsertCommitment(migratedCommitmentHash);
+            Assert.Equal(await _deployment.Pool.CurrentRootQueryAsync(), stateTree.RootAsBigInteger);
+
+            var postMigrationResult = await RunNodeScript("withdraw.mjs", new
+            {
+                rpcUrl = GETH_RPC_URL,
+                chainId = GETH_CHAIN_ID,
+                entrypointAddress = _deployment.Entrypoint.ContractAddress,
+                poolAddress = _deployment.Pool.ContractAddress,
+                privateKey = OWNER_PRIVATE_KEY,
+                artifactsDir = _artifactsDir.Replace("\\", "/"),
+                mnemonic = TEST_MNEMONIC,
+                scope = _scope.ToString(),
+                existingValue = depositValue.ToString(),
+                existingLabel = legacyLabel.ToString(),
+                existingNullifier = migrationResult["newNullifier"]!.ToString(),
+                existingSecret = migrationResult["newSecret"]!.ToString(),
+                stateLeaves = new[]
+                {
+                    legacyCommitmentHash.ToString(),
+                    migratedCommitmentHash.ToString()
+                },
+                stateLeafIndex = "1",
+                aspLeaves = new[] { legacyLabel.ToString() },
+                aspLeafIndex = "0",
+                withdrawnValue = (depositValue - postMigrationValue).ToString(),
+                recipientAddress = _account.Address,
+                relayerAddress = _account.Address,
+                relayFeeBps = "0",
+                childIndex = "1"
+            });
+
+            Assert.True(postMigrationResult["success"]!.Value<bool>());
+            var postMigrationCommitmentHash = BigInteger.Parse(
+                postMigrationResult["newCommitmentHash"]!.ToString());
+            _output.WriteLine($"TS post-migration commitment: {postMigrationCommitmentHash}");
+
+            stateTree.InsertCommitment(postMigrationCommitmentHash);
+            Assert.Equal(await _deployment.Pool.CurrentRootQueryAsync(), stateTree.RootAsBigInteger);
+
+            var pp = PrivacyPool.FromDeployment(_web3, _deployment, TEST_MNEMONIC);
+            await pp.InitializeAsync();
+
+            var sync = await pp.SyncFromChainAsync();
+            Assert.Equal(2, sync.PoolAccounts.Count);
+
+            var recoveredLegacy = sync.PoolAccounts.Single(
+                account => account.Deposit.Commitment.CommitmentHash == legacyCommitmentHash);
+            Assert.True(recoveredLegacy.IsMigrated);
+            Assert.False(recoveredLegacy.IsSpendable);
+            Assert.Single(recoveredLegacy.Withdrawals);
+            Assert.True(recoveredLegacy.Withdrawals[0].IsMigration);
+
+            var recoveredSafe = sync.PoolAccounts.Single(
+                account => account.Deposit.Commitment.CommitmentHash == migratedCommitmentHash);
+            Assert.False(recoveredSafe.IsMigrated);
+            Assert.Equal(migratedCommitmentHash, recoveredSafe.Deposit.Commitment.CommitmentHash);
+            Assert.Equal(postMigrationCommitmentHash, recoveredSafe.LatestCommitment.Commitment.CommitmentHash);
+            Assert.Equal(postMigrationValue, recoveredSafe.SpendableValue);
+            Assert.Equal(2, recoveredSafe.Withdrawals.Count);
+            Assert.True(recoveredSafe.IsSpendable);
+
+            var spendable = pp.GetSpendableAccounts();
+            Assert.Single(spendable);
+            Assert.Equal(postMigrationCommitmentHash, spendable[0].LatestCommitment.Commitment.CommitmentHash);
+        }
+
         private const string FUZZ_ERC20_BYTECODE = "0x608060405234801561000f575f5ffd5b50604080518082018252600980825268046757a7a45524332360bc1b602080840182905284518086019095529184529083015290600361004f838261010e565b50600461005c828261010e565b5050600580546001600160a01b03191633179055506101c8565b634e487b7160e01b5f52604160045260245ffd5b600181811c9082168061009e57607f821691505b6020821081036100bc57634e487b7160e01b5f52602260045260245ffd5b50919050565b601f82111561010957805f5260205f20601f840160051c810160208510156100e75750805b601f840160051c820191505b81811015610106575f81556001016100f3565b50505b505050565b81516001600160401b0381111561012757610127610076565b61013b81610135845461008a565b846100c2565b6020601f82116001811461016d575f83156101565750848201515b5f19600385901b1c1916600184901b178455610106565b5f84815260208120601f198516915b8281101561019c578785015182556020948501946001909201910161017c565b50848210156101b957868401515f19600387901b60f8161c191681555b50505050600190811b01905550565b610a22806101d55f395ff3fe608060405234801561000f575f5ffd5b50600436106100c4575f3560e01c806340c10f191161007d5780639dc29fac116100585780639dc29fac1461018f578063a9059cbb146101a2578063dd62ed3e146101b5575f5ffd5b806340c10f191461013d57806370a082311461015257806395d89b4114610187575f5ffd5b806318160ddd116100ad57806318160ddd1461010957806323b872dd1461011b578063313ce5671461012e575f5ffd5b806306fdde03146100c8578063095ea7b3146100e6575b5f5ffd5b6100d06101fa565b6040516100dd919061086b565b60405180910390f35b6100f96100f43660046108e6565b61028a565b60405190151581526020016100dd565b6002545b6040519081526020016100dd565b6100f961012936600461090e565b6102a3565b604051601281526020016100dd565b61015061014b3660046108e6565b6102c6565b005b61010d610160366004610948565b73ffffffffffffffffffffffffffffffffffffffff165f9081526020819052604090205490565b6100d06102d4565b61015061019d3660046108e6565b6102e3565b6100f96101b03660046108e6565b6102ed565b61010d6101c3366004610968565b73ffffffffffffffffffffffffffffffffffffffff9182165f90815260016020908152604080832093909416825291909152205490565b60606003805461020990610999565b80601f016020809104026020016040519081016040528092919081815260200182805461023590610999565b80156102805780601f1061025757610100808354040283529160200191610280565b820191905f5260205f20905b81548152906001019060200180831161026357829003601f168201915b5050505050905090565b5f3361029781858561033e565b60019150505b92915050565b5f336102b0858285610350565b6102bb858585610422565b506001949350505050565b6102d082826104cb565b5050565b60606004805461020990610999565b6102d08282610525565b6005545f90339073ffffffffffffffffffffffffffffffffffffffff168103610333576005546103339073ffffffffffffffffffffffffffffffffffffffff16846104cb565b610297818585610422565b61034b838383600161057f565b505050565b73ffffffffffffffffffffffffffffffffffffffff8381165f908152600160209081526040808320938616835292905220547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff811461041c578181101561040e576040517ffb8f41b200000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff8416600482015260248101829052604481018390526064015b60405180910390fd5b61041c84848484035f61057f565b50505050565b73ffffffffffffffffffffffffffffffffffffffff8316610471576040517f96c6fd1e0000000000000000000000000000000000000000000000000000000081525f6004820152602401610405565b73ffffffffffffffffffffffffffffffffffffffff82166104c0576040517fec442f050000000000000000000000000000000000000000000000000000000081525f6004820152602401610405565b61034b8383836106c4565b73ffffffffffffffffffffffffffffffffffffffff821661051a576040517fec442f050000000000000000000000000000000000000000000000000000000081525f6004820152602401610405565b6102d05f83836106c4565b73ffffffffffffffffffffffffffffffffffffffff8216610574576040517f96c6fd1e0000000000000000000000000000000000000000000000000000000081525f6004820152602401610405565b6102d0825f836106c4565b73ffffffffffffffffffffffffffffffffffffffff84166105ce576040517fe602df050000000000000000000000000000000000000000000000000000000081525f6004820152602401610405565b73ffffffffffffffffffffffffffffffffffffffff831661061d576040517f94280d620000000000000000000000000000000000000000000000000000000081525f6004820152602401610405565b73ffffffffffffffffffffffffffffffffffffffff8085165f908152600160209081526040808320938716835292905220829055801561041c578273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925846040516106b691815260200190565b60405180910390a350505050565b73ffffffffffffffffffffffffffffffffffffffff83166106fb578060025f8282546106f091906109ea565b909155506107ab9050565b73ffffffffffffffffffffffffffffffffffffffff83165f9081526020819052604090205481811015610780576040517fe450d38c00000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff851660048201526024810182905260448101839052606401610405565b73ffffffffffffffffffffffffffffffffffffffff84165f9081526020819052604090209082900390555b73ffffffffffffffffffffffffffffffffffffffff82166107d4576002805482900390556107ff565b73ffffffffffffffffffffffffffffffffffffffff82165f9081526020819052604090208054820190555b8173ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161085e91815260200190565b60405180910390a3505050565b602081525f82518060208401528060208501604085015e5f6040828501015260407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f83011684010191505092915050565b803573ffffffffffffffffffffffffffffffffffffffff811681146108e1575f5ffd5b919050565b5f5f604083850312156108f7575f5ffd5b610900836108be565b946020939093013593505050565b5f5f5f60608486031215610920575f5ffd5b610929846108be565b9250610937602085016108be565b929592945050506040919091013590565b5f60208284031215610958575f5ffd5b610961826108be565b9392505050565b5f5f60408385031215610979575f5ffd5b610982836108be565b9150610990602084016108be565b90509250929050565b600181811c908216806109ad57607f821691505b6020821081036109e4577f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b50919050565b8082018082111561029d577f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd";
 
         private async Task<(PrivacyPoolERC20DeploymentResult deployment, string tokenAddress, BigInteger scope)> DeployERC20PoolAsync()
@@ -574,18 +782,23 @@ namespace Nethereum.PrivacyPools.CrossSdk.Tests
             Directory.CreateDirectory(_artifactsDir);
 
             var source = new PrivacyPoolCircuitSource();
-            foreach (var circuit in new[] { "commitment", "withdrawal" })
+            foreach (var artifact in new[]
             {
-                if (!source.HasCircuit(circuit))
+                (SourceCircuit: "commitment", OutputCircuit: "commitment"),
+                (SourceCircuit: "withdrawal", OutputCircuit: "withdraw")
+            })
+            {
+                if (!source.HasCircuit(artifact.SourceCircuit))
                 {
-                    _output.WriteLine($"WARNING: {circuit} circuit not available");
+                    _output.WriteLine($"WARNING: {artifact.SourceCircuit} circuit not available");
                     continue;
                 }
-                var wasm = await source.GetWasmAsync(circuit);
-                var zkey = await source.GetZkeyAsync(circuit);
-                await File.WriteAllBytesAsync(Path.Combine(_artifactsDir, $"{circuit}.wasm"), wasm);
-                await File.WriteAllBytesAsync(Path.Combine(_artifactsDir, $"{circuit}.zkey"), zkey);
-                _output.WriteLine($"Extracted {circuit} artifacts ({wasm.Length + zkey.Length} bytes)");
+                var wasm = await source.GetWasmAsync(artifact.SourceCircuit);
+                var zkey = await source.GetZkeyAsync(artifact.SourceCircuit);
+                await File.WriteAllBytesAsync(Path.Combine(_artifactsDir, $"{artifact.OutputCircuit}.wasm"), wasm);
+                await File.WriteAllBytesAsync(Path.Combine(_artifactsDir, $"{artifact.OutputCircuit}.zkey"), zkey);
+                _output.WriteLine(
+                    $"Extracted {artifact.OutputCircuit} artifacts ({wasm.Length + zkey.Length} bytes)");
             }
         }
 

--- a/tests/Nethereum.PrivacyPools.CrossSdk.Tests/scripts/.gitignore
+++ b/tests/Nethereum.PrivacyPools.CrossSdk.Tests/scripts/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 package-lock.json
+package/
+*.tgz

--- a/tests/Nethereum.PrivacyPools.CrossSdk.Tests/scripts/deposit-legacy.mjs
+++ b/tests/Nethereum.PrivacyPools.CrossSdk.Tests/scripts/deposit-legacy.mjs
@@ -1,0 +1,76 @@
+import {
+  generateDepositSecrets,
+  hashPrecommitment,
+  getCommitment
+} from '@0xbow/privacy-pools-core-sdk';
+import { bytesToNumber } from 'viem/utils';
+import { mnemonicToAccount } from 'viem/accounts';
+import { poseidon } from 'maci-crypto/build/ts/hashing.js';
+import { parseEventLogs } from 'viem';
+import { readInput, createClients, entrypointAbi, poolAbi } from './helpers.mjs';
+
+const input = readInput();
+const { rpcUrl, chainId, entrypointAddress, poolAddress, privateKey, mnemonic, depositIndex, valueWei, scope: scopeStr } = input;
+
+const { publicClient, walletClient, account } = createClients(rpcUrl, chainId, privateKey);
+
+// Legacy key derivation using bytesToNumber (53-bit lossy)
+const key1 = bytesToNumber(
+  mnemonicToAccount(mnemonic, { accountIndex: 0 }).getHdKey().privateKey
+);
+const key2 = bytesToNumber(
+  mnemonicToAccount(mnemonic, { accountIndex: 1 }).getHdKey().privateKey
+);
+const masterNullifier = poseidon([BigInt(key1)]);
+const masterSecret = poseidon([BigInt(key2)]);
+const keys = { masterNullifier, masterSecret };
+
+const scope = BigInt(scopeStr);
+const { nullifier, secret } = generateDepositSecrets(keys, scope, BigInt(depositIndex));
+const precommitment = hashPrecommitment(nullifier, secret);
+
+const txHash = await walletClient.writeContract({
+  address: entrypointAddress,
+  abi: entrypointAbi,
+  functionName: 'deposit',
+  args: [precommitment],
+  value: BigInt(valueWei),
+  gas: 5_000_000n
+});
+
+const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+const poolLogs = parseEventLogs({
+  abi: poolAbi,
+  logs: receipt.logs,
+  eventName: 'Deposited'
+});
+
+if (poolLogs.length === 0) {
+  console.log(JSON.stringify({
+    error: 'No Deposited event found',
+    receiptStatus: receipt.status,
+    logCount: receipt.logs.length
+  }));
+  process.exit(1);
+}
+
+const evt = poolLogs[0].args;
+const commitment = getCommitment(BigInt(valueWei), evt.label, nullifier, secret);
+
+const result = {
+  commitmentHash: commitment.hash.toString(),
+  label: evt.label.toString(),
+  precommitment: precommitment.toString(),
+  nullifier: nullifier.toString(),
+  secret: secret.toString(),
+  value: valueWei,
+  scope: scope.toString(),
+  masterNullifier: keys.masterNullifier.toString(),
+  masterSecret: keys.masterSecret.toString(),
+  txHash: txHash,
+  blockNumber: receipt.blockNumber.toString(),
+  onChainCommitment: evt.commitment.toString()
+};
+
+console.log(JSON.stringify(result));

--- a/tests/Nethereum.PrivacyPools.CrossSdk.Tests/scripts/package.json
+++ b/tests/Nethereum.PrivacyPools.CrossSdk.Tests/scripts/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@0xbow/privacy-pools-core-sdk": "file:../../../../privacy-pools-core/packages/sdk",
+    "@0xbow/privacy-pools-core-sdk": "1.2.0",
+    "maci-crypto": "2.5.0",
     "viem": "^2.22.0",
     "snarkjs": "^0.7.5"
   }

--- a/tests/Nethereum.PrivacyPools.CrossSdk.Tests/scripts/withdraw.mjs
+++ b/tests/Nethereum.PrivacyPools.CrossSdk.Tests/scripts/withdraw.mjs
@@ -4,8 +4,7 @@ import {
   generateWithdrawalSecrets,
   hashPrecommitment,
   generateMerkleProof,
-  calculateContext,
-  bigintToHex
+  calculateContext
 } from '@0xbow/privacy-pools-core-sdk';
 import { parseEventLogs } from 'viem';
 import { readInput, createClients, entrypointAbi, poolAbi, formatProofForSolidity, buildRelayData } from './helpers.mjs';
@@ -17,14 +16,14 @@ const {
   existingValue, existingLabel, existingNullifier, existingSecret,
   stateLeaves, stateLeafIndex,
   aspLeaves, aspLeafIndex,
-  withdrawnValue, recipientAddress, relayerAddress, relayFeeBps
+  withdrawnValue, recipientAddress, relayerAddress, relayFeeBps, childIndex
 } = input;
 
 const { publicClient, walletClient } = createClients(rpcUrl, chainId, privateKey);
 
 const keys = generateMasterKeys(mnemonic);
 const { nullifier: newNullifier, secret: newSecret } = generateWithdrawalSecrets(
-  keys, BigInt(existingLabel), 0n
+  keys, BigInt(existingLabel), BigInt(childIndex ?? '0')
 );
 
 const stateLeavesBigInt = stateLeaves.map(l => BigInt(l));
@@ -61,8 +60,8 @@ const witnessInput = {
   context: BigInt(context).toString()
 };
 
-const wasmPath = `${artifactsDir}/withdrawal.wasm`;
-const zkeyPath = `${artifactsDir}/withdrawal.zkey`;
+const wasmPath = `${artifactsDir}/withdraw.wasm`;
+const zkeyPath = `${artifactsDir}/withdraw.zkey`;
 
 const { proof, publicSignals } = await fullProve(witnessInput, wasmPath, zkeyPath);
 

--- a/tests/Nethereum.PrivacyPools.Tests/AccountTests.cs
+++ b/tests/Nethereum.PrivacyPools.Tests/AccountTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Numerics;
 using Nethereum.Accounts.Bip32;
 using Nethereum.Documentation;
@@ -10,12 +12,16 @@ namespace Nethereum.PrivacyPools.Tests
     {
         private const string TEST_MNEMONIC = "test test test test test test test test test test test junk";
 
+        // ───────────────────────────────────────────────────────────
+        //  Legacy tests (53-bit lossy path via CreateLegacy)
+        // ───────────────────────────────────────────────────────────
+
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
         [NethereumDocExample(DocSection.Protocols, "account-recovery", "Create account from mnemonic")]
-        public void CreateAccount_FromMnemonic_DerivesMasterKeys()
+        public void Legacy_CreateAccount_FromMnemonic_DerivesMasterKeys()
         {
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
 
             Assert.NotEqual(BigInteger.Zero, account.MasterNullifier);
             Assert.NotEqual(BigInteger.Zero, account.MasterSecret);
@@ -24,10 +30,10 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void CreateAccount_SameMnemonic_SameKeys()
+        public void Legacy_CreateAccount_SameMnemonic_SameKeys()
         {
-            var account1 = new PrivacyPoolAccount(TEST_MNEMONIC);
-            var account2 = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account1 = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
+            var account2 = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
 
             Assert.Equal(account1.MasterNullifier, account2.MasterNullifier);
             Assert.Equal(account1.MasterSecret, account2.MasterSecret);
@@ -35,11 +41,11 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void CreateAccount_DifferentMnemonics_DifferentKeys()
+        public void Legacy_CreateAccount_DifferentMnemonics_DifferentKeys()
         {
             var mnemonic2 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-            var account1 = new PrivacyPoolAccount(TEST_MNEMONIC);
-            var account2 = new PrivacyPoolAccount(mnemonic2);
+            var account1 = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
+            var account2 = PrivacyPoolAccount.CreateLegacy(mnemonic2);
 
             Assert.NotEqual(account1.MasterNullifier, account2.MasterNullifier);
             Assert.NotEqual(account1.MasterSecret, account2.MasterSecret);
@@ -47,7 +53,7 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void MasterKeys_MatchExpectedDerivation()
+        public void Legacy_MasterKeys_MatchExpectedDerivation()
         {
             var wallet = new MinimalHDWallet(TEST_MNEMONIC);
             var key1Bytes = wallet.GetKeyFromPath("m/44'/60'/0'/0/0").GetPrivateKeyAsBytes();
@@ -57,16 +63,16 @@ namespace Nethereum.PrivacyPools.Tests
             var expectedNullifier = hasherT1.Hash(PrivacyPoolAccount.BytesToBigIntViaDouble(key1Bytes));
             var expectedSecret = hasherT1.Hash(PrivacyPoolAccount.BytesToBigIntViaDouble(key2Bytes));
 
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             Assert.Equal(expectedNullifier, account.MasterNullifier);
             Assert.Equal(expectedSecret, account.MasterSecret);
         }
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void DepositSecrets_Deterministic_SameScopeAndIndex()
+        public void Legacy_DepositSecrets_Deterministic_SameScopeAndIndex()
         {
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             BigInteger scope = 12345;
 
             var (n1, s1) = account.CreateDepositSecrets(scope, 0);
@@ -78,9 +84,9 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void DepositSecrets_DifferentPerIndex()
+        public void Legacy_DepositSecrets_DifferentPerIndex()
         {
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             BigInteger scope = 12345;
 
             var (n0, s0) = account.CreateDepositSecrets(scope, 0);
@@ -92,9 +98,9 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void DepositSecrets_DifferentPerScope()
+        public void Legacy_DepositSecrets_DifferentPerScope()
         {
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
 
             var (n1, s1) = account.CreateDepositSecrets(100, 0);
             var (n2, s2) = account.CreateDepositSecrets(200, 0);
@@ -105,9 +111,9 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void WithdrawalSecrets_Deterministic()
+        public void Legacy_WithdrawalSecrets_Deterministic()
         {
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             BigInteger label = 99999;
 
             var (n1, s1) = account.CreateWithdrawalSecrets(label, 0);
@@ -119,9 +125,9 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void WithdrawalSecrets_DifferentFromDepositSecrets_WhenDifferentDomains()
+        public void Legacy_WithdrawalSecrets_DifferentFromDepositSecrets_WhenDifferentDomains()
         {
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             BigInteger scope = 12345;
             BigInteger label = PrivacyPoolCommitment.ComputeLabel(scope, BigInteger.Zero);
 
@@ -134,9 +140,9 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void CreateDepositCommitment_MatchesManualCreation()
+        public void Legacy_CreateDepositCommitment_MatchesManualCreation()
         {
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             BigInteger scope = 12345;
             BigInteger value = 1_000_000_000_000_000_000;
             BigInteger label = 42;
@@ -153,9 +159,9 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void Precommitment_MatchesOnChainDeposit()
+        public void Legacy_Precommitment_MatchesOnChainDeposit()
         {
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             BigInteger scope = 12345;
 
             var (nullifier, secret) = account.CreateDepositSecrets(scope, 0);
@@ -168,20 +174,20 @@ namespace Nethereum.PrivacyPools.Tests
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
         [NethereumDocExample(DocSection.Protocols, "account-recovery", "Deposit and recover from mnemonic", Order = 2)]
-        public void FullUserJourney_DepositAndRecover()
+        public void Legacy_FullUserJourney_DepositAndRecover()
         {
             var scope = BigInteger.Parse("98765");
             var depositValue = BigInteger.Parse("1000000000000000000");
             var label = PrivacyPoolCommitment.ComputeLabel(scope, BigInteger.Zero);
 
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             var (nullifier, secret) = account.CreateDepositSecrets(scope, depositIndex: 0);
             var precommitment = account.ComputePrecommitment(nullifier, secret);
 
             var commitment = PrivacyPoolCommitment.Create(depositValue, label, nullifier, secret);
             Assert.Equal(precommitment, commitment.Precommitment);
 
-            var recoveredAccount = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var recoveredAccount = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             var (recoveredN, recoveredS) = recoveredAccount.CreateDepositSecrets(scope, depositIndex: 0);
             var recoveredPrecommitment = recoveredAccount.ComputePrecommitment(recoveredN, recoveredS);
 
@@ -195,14 +201,14 @@ namespace Nethereum.PrivacyPools.Tests
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
         [NethereumDocExample(DocSection.Protocols, "account-recovery", "Full deposit-withdraw-recover cycle", Order = 3)]
-        public void FullUserJourney_DepositWithdrawRecover()
+        public void Legacy_FullUserJourney_DepositWithdrawRecover()
         {
             var scope = BigInteger.Parse("98765");
             var depositValue = BigInteger.Parse("1000000000000000000");
             var label = PrivacyPoolCommitment.ComputeLabel(scope, BigInteger.Zero);
             var withdrawnValue = depositValue / 2;
 
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
 
             var deposit = account.CreateDepositCommitment(scope, 0, depositValue, label);
 
@@ -214,7 +220,7 @@ namespace Nethereum.PrivacyPools.Tests
                 depositValue - withdrawnValue, label, wNullifier, wSecret);
             tree.InsertCommitment(newCommitment.CommitmentHash);
 
-            var recoveredAccount = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var recoveredAccount = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             var recoveredDeposit = recoveredAccount.CreateDepositCommitment(scope, 0, depositValue, label);
             Assert.Equal(deposit.CommitmentHash, recoveredDeposit.CommitmentHash);
 
@@ -252,13 +258,312 @@ namespace Nethereum.PrivacyPools.Tests
             Assert.Equal(halfValue, poolAccount.SpendableValue);
             Assert.True(poolAccount.IsSpendable);
 
+            poolAccount.IsMigrated = true;
+            Assert.False(poolAccount.IsSpendable);
+
+            poolAccount.IsMigrated = false;
             poolAccount.IsRagequitted = true;
             Assert.False(poolAccount.IsSpendable);
         }
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void MnemonicGeneration_ValidRoundTrip()
+        public void Legacy_MnemonicGeneration_ValidRoundTrip()
+        {
+            var mnemonic = Bip39.GenerateMnemonic(12);
+            var words = mnemonic.Split(' ');
+            Assert.Equal(12, words.Length);
+
+            var account1 = PrivacyPoolAccount.CreateLegacy(mnemonic);
+            var account2 = PrivacyPoolAccount.CreateLegacy(mnemonic);
+            Assert.Equal(account1.MasterNullifier, account2.MasterNullifier);
+            Assert.Equal(account1.MasterSecret, account2.MasterSecret);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Legacy_MultipleDeposits_EachHasUniqueSecrets()
+        {
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
+            BigInteger scope = 12345;
+
+            var precommitments = new System.Collections.Generic.HashSet<BigInteger>();
+            for (int i = 0; i < 10; i++)
+            {
+                var (n, s) = account.CreateDepositSecrets(scope, i);
+                var pre = account.ComputePrecommitment(n, s);
+                Assert.True(precommitments.Add(pre), $"Duplicate precommitment at index {i}");
+            }
+        }
+
+        // ───────────────────────────────────────────────────────────
+        //  Safe tests (full 256-bit BytesToBigInt via new constructor)
+        // ───────────────────────────────────────────────────────────
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_CreateAccount_FromMnemonic_DerivesMasterKeys()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+
+            Assert.NotEqual(BigInteger.Zero, account.MasterNullifier);
+            Assert.NotEqual(BigInteger.Zero, account.MasterSecret);
+            Assert.NotEqual(account.MasterNullifier, account.MasterSecret);
+
+            Assert.Equal(
+                BigInteger.Parse("20068762160393292801596226195912281868434195939362930533775271887246872084568"),
+                account.MasterNullifier);
+            Assert.Equal(
+                BigInteger.Parse("4263194520628581151689140073493505946870598678660509318310629023735624352890"),
+                account.MasterSecret);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_CreateAccount_SameMnemonic_SameKeys()
+        {
+            var account1 = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account2 = new PrivacyPoolAccount(TEST_MNEMONIC);
+
+            Assert.Equal(account1.MasterNullifier, account2.MasterNullifier);
+            Assert.Equal(account1.MasterSecret, account2.MasterSecret);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_CreateAccount_DifferentMnemonics_DifferentKeys()
+        {
+            var mnemonic2 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+            var account1 = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account2 = new PrivacyPoolAccount(mnemonic2);
+
+            Assert.NotEqual(account1.MasterNullifier, account2.MasterNullifier);
+            Assert.NotEqual(account1.MasterSecret, account2.MasterSecret);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_MasterKeys_MatchExpectedDerivation()
+        {
+            var wallet = new MinimalHDWallet(TEST_MNEMONIC);
+            var key1Bytes = wallet.GetKeyFromPath("m/44'/60'/0'/0/0").GetPrivateKeyAsBytes();
+            var key2Bytes = wallet.GetKeyFromPath("m/44'/60'/1'/0/0").GetPrivateKeyAsBytes();
+
+            var hasherT1 = new PoseidonHasher(PoseidonParameterPreset.CircomT1);
+            var expectedNullifier = hasherT1.Hash(PrivacyPoolAccount.BytesToBigInt(key1Bytes));
+            var expectedSecret = hasherT1.Hash(PrivacyPoolAccount.BytesToBigInt(key2Bytes));
+
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            Assert.Equal(expectedNullifier, account.MasterNullifier);
+            Assert.Equal(expectedSecret, account.MasterSecret);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_DepositSecrets_Deterministic_SameScopeAndIndex()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            BigInteger scope = 12345;
+
+            var (n1, s1) = account.CreateDepositSecrets(scope, 0);
+            var (n2, s2) = account.CreateDepositSecrets(scope, 0);
+
+            Assert.Equal(n1, n2);
+            Assert.Equal(s1, s2);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_DepositSecrets_DifferentPerIndex()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            BigInteger scope = 12345;
+
+            var (n0, s0) = account.CreateDepositSecrets(scope, 0);
+            var (n1, s1) = account.CreateDepositSecrets(scope, 1);
+
+            Assert.NotEqual(n0, n1);
+            Assert.NotEqual(s0, s1);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_DepositSecrets_DifferentPerScope()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+
+            var (n1, s1) = account.CreateDepositSecrets(100, 0);
+            var (n2, s2) = account.CreateDepositSecrets(200, 0);
+
+            Assert.NotEqual(n1, n2);
+            Assert.NotEqual(s1, s2);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_DepositSecrets_MatchExpectedValues()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            BigInteger scope = 12345;
+
+            var (n0, s0) = account.CreateDepositSecrets(scope, 0);
+            Assert.Equal(
+                BigInteger.Parse("18799083407603226543886233241239845601765199220468928197737203484264534974328"),
+                n0);
+            Assert.Equal(
+                BigInteger.Parse("15330187620018206781186163615746153118874798050558698314725491067582470174001"),
+                s0);
+
+            var (n1, s1) = account.CreateDepositSecrets(scope, 1);
+            Assert.Equal(
+                BigInteger.Parse("19680772378616183859773159152052009318547743051040396428045076615829991543806"),
+                n1);
+            Assert.Equal(
+                BigInteger.Parse("6904700659503672703719873229706944332624720037700303163123064806497600512042"),
+                s1);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_WithdrawalSecrets_Deterministic()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            BigInteger label = 99999;
+
+            var (n1, s1) = account.CreateWithdrawalSecrets(label, 0);
+            var (n2, s2) = account.CreateWithdrawalSecrets(label, 0);
+
+            Assert.Equal(n1, n2);
+            Assert.Equal(s1, s2);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_WithdrawalSecrets_MatchExpectedValues()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            BigInteger label = 42;
+
+            var (n0, s0) = account.CreateWithdrawalSecrets(label, 0);
+            Assert.Equal(
+                BigInteger.Parse("1980872316991559359161330914646252222519000137922535899794170500197294191442"),
+                n0);
+            Assert.Equal(
+                BigInteger.Parse("21563020234007267038495623498396204986995053023966409630658634968140121948420"),
+                s0);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_WithdrawalSecrets_DifferentFromDepositSecrets_WhenDifferentDomains()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            BigInteger scope = 12345;
+            BigInteger label = PrivacyPoolCommitment.ComputeLabel(scope, BigInteger.Zero);
+
+            var (dn, ds) = account.CreateDepositSecrets(scope, 0);
+            var (wn, ws) = account.CreateWithdrawalSecrets(label, 0);
+
+            Assert.NotEqual(dn, wn);
+            Assert.NotEqual(ds, ws);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_CreateDepositCommitment_MatchesManualCreation()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            BigInteger scope = 12345;
+            BigInteger value = 1_000_000_000_000_000_000;
+            BigInteger label = 42;
+
+            var commitment = account.CreateDepositCommitment(scope, 0, value, label);
+
+            var (nullifier, secret) = account.CreateDepositSecrets(scope, 0);
+            var manual = PrivacyPoolCommitment.Create(value, label, nullifier, secret);
+
+            Assert.Equal(manual.CommitmentHash, commitment.CommitmentHash);
+            Assert.Equal(manual.NullifierHash, commitment.NullifierHash);
+            Assert.Equal(manual.Precommitment, commitment.Precommitment);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_Precommitment_MatchesOnChainDeposit()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            BigInteger scope = 12345;
+
+            var (nullifier, secret) = account.CreateDepositSecrets(scope, 0);
+            var precommitment = account.ComputePrecommitment(nullifier, secret);
+
+            var commitment = PrivacyPoolCommitment.Create(100, 1, nullifier, secret);
+            Assert.Equal(commitment.Precommitment, precommitment);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_FullUserJourney_DepositAndRecover()
+        {
+            var scope = BigInteger.Parse("98765");
+            var depositValue = BigInteger.Parse("1000000000000000000");
+            var label = PrivacyPoolCommitment.ComputeLabel(scope, BigInteger.Zero);
+
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var (nullifier, secret) = account.CreateDepositSecrets(scope, depositIndex: 0);
+            var precommitment = account.ComputePrecommitment(nullifier, secret);
+
+            var commitment = PrivacyPoolCommitment.Create(depositValue, label, nullifier, secret);
+            Assert.Equal(precommitment, commitment.Precommitment);
+
+            var recoveredAccount = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var (recoveredN, recoveredS) = recoveredAccount.CreateDepositSecrets(scope, depositIndex: 0);
+            var recoveredPrecommitment = recoveredAccount.ComputePrecommitment(recoveredN, recoveredS);
+
+            Assert.Equal(precommitment, recoveredPrecommitment);
+
+            var recoveredCommitment = PrivacyPoolCommitment.Create(depositValue, label, recoveredN, recoveredS);
+            Assert.Equal(commitment.CommitmentHash, recoveredCommitment.CommitmentHash);
+            Assert.Equal(commitment.NullifierHash, recoveredCommitment.NullifierHash);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_FullUserJourney_DepositWithdrawRecover()
+        {
+            var scope = BigInteger.Parse("98765");
+            var depositValue = BigInteger.Parse("1000000000000000000");
+            var label = PrivacyPoolCommitment.ComputeLabel(scope, BigInteger.Zero);
+            var withdrawnValue = depositValue / 2;
+
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+
+            var deposit = account.CreateDepositCommitment(scope, 0, depositValue, label);
+
+            var tree = new PoseidonMerkleTree();
+            tree.InsertCommitment(deposit.CommitmentHash);
+
+            var (wNullifier, wSecret) = account.CreateWithdrawalSecrets(label, childIndex: 0);
+            var newCommitment = PrivacyPoolCommitment.Create(
+                depositValue - withdrawnValue, label, wNullifier, wSecret);
+            tree.InsertCommitment(newCommitment.CommitmentHash);
+
+            var recoveredAccount = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var recoveredDeposit = recoveredAccount.CreateDepositCommitment(scope, 0, depositValue, label);
+            Assert.Equal(deposit.CommitmentHash, recoveredDeposit.CommitmentHash);
+
+            var (rwN, rwS) = recoveredAccount.CreateWithdrawalSecrets(label, childIndex: 0);
+            var recoveredNewCommitment = PrivacyPoolCommitment.Create(
+                depositValue - withdrawnValue, label, rwN, rwS);
+            Assert.Equal(newCommitment.CommitmentHash, recoveredNewCommitment.CommitmentHash);
+
+            Assert.True(tree.VerifyInclusionProof(
+                tree.GenerateInclusionProof(1), newCommitment.CommitmentHash));
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void Safe_MnemonicGeneration_ValidRoundTrip()
         {
             var mnemonic = Bip39.GenerateMnemonic(12);
             var words = mnemonic.Split(' ');
@@ -272,7 +577,7 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-Account")]
-        public void MultipleDeposits_EachHasUniqueSecrets()
+        public void Safe_MultipleDeposits_EachHasUniqueSecrets()
         {
             var account = new PrivacyPoolAccount(TEST_MNEMONIC);
             BigInteger scope = 12345;
@@ -284,6 +589,435 @@ namespace Nethereum.PrivacyPools.Tests
                 var pre = account.ComputePrecommitment(n, s);
                 Assert.True(precommitments.Add(pre), $"Duplicate precommitment at index {i}");
             }
+        }
+
+        // ───────────────────────────────────────────────────────────
+        //  Migration discovery
+        // ───────────────────────────────────────────────────────────
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void RecoverAccounts_WithoutLegacyContext_ThrowsToAvoidSkippingMigratedFunds()
+        {
+            BigInteger scope = 0;
+            BigInteger label = 42;
+            BigInteger depositValue = 1000;
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var pp = new PrivacyPool(new Nethereum.Web3.Web3(), "0xentry", "0xpool", account);
+
+            var (nullifier, secret) = account.CreateDepositSecrets(scope, 0);
+            var precommitment = account.ComputePrecommitment(nullifier, secret);
+            var commitment = PrivacyPoolCommitment.Create(depositValue, label, nullifier, secret);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => pp.RecoverAccounts(
+                new List<PoolDepositEventData>
+                {
+                    new PoolDepositEventData
+                    {
+                        Commitment = commitment.CommitmentHash,
+                        Label = label,
+                        Value = depositValue,
+                        PrecommitmentHash = precommitment,
+                        BlockNumber = 100,
+                        TransactionHash = "0xabc"
+                    }
+                },
+                new List<PoolWithdrawalEventData>(),
+                new List<PoolRagequitEventData>(),
+                new List<PoolLeafEventData>
+                {
+                    new PoolLeafEventData { Leaf = commitment.CommitmentHash, Index = 0 }
+                }));
+
+            Assert.Contains("legacy account", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void RecoverSafeAccounts_WithSafeAccountOnly_RecoversSafeDeposits()
+        {
+            BigInteger scope = 0;
+            BigInteger label = 42;
+            BigInteger depositValue = 1000;
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var pp = new PrivacyPool(new Nethereum.Web3.Web3(), "0xentry", "0xpool", account);
+
+            var (nullifier, secret) = account.CreateDepositSecrets(scope, 0);
+            var precommitment = account.ComputePrecommitment(nullifier, secret);
+            var commitment = PrivacyPoolCommitment.Create(depositValue, label, nullifier, secret);
+
+            var recovered = pp.RecoverSafeAccounts(
+                new List<PoolDepositEventData>
+                {
+                    new PoolDepositEventData
+                    {
+                        Commitment = commitment.CommitmentHash,
+                        Label = label,
+                        Value = depositValue,
+                        PrecommitmentHash = precommitment,
+                        BlockNumber = 100,
+                        TransactionHash = "0xabc"
+                    }
+                },
+                new List<PoolWithdrawalEventData>(),
+                new List<PoolRagequitEventData>(),
+                new List<PoolLeafEventData>
+                {
+                    new PoolLeafEventData { Leaf = commitment.CommitmentHash, Index = 0 }
+                });
+
+            var poolAccount = Assert.Single(recovered);
+            Assert.Equal(commitment.CommitmentHash, poolAccount.Deposit.Commitment.CommitmentHash);
+            Assert.True(poolAccount.IsSpendable);
+            Assert.Null(pp.LegacyAccount);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void RecoverAccounts_WithExplicitLegacyContext_RecoversMigratedFunds()
+        {
+            BigInteger scope = 0;
+            var legacyAccount = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
+            var safeAccount = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var pp = new PrivacyPool(
+                new Nethereum.Web3.Web3(),
+                "0xentry",
+                "0xpool",
+                safeAccount,
+                legacyAccount);
+
+            BigInteger depositIndex = 0;
+            BigInteger depositValue = 1000;
+            var (legN, legS) = legacyAccount.CreateDepositSecrets(scope, depositIndex);
+            var legacyPrecommitment = legacyAccount.ComputePrecommitment(legN, legS);
+            BigInteger label = 42;
+            var legacyCommitment = PrivacyPoolCommitment.Create(depositValue, label, legN, legS);
+
+            var (safeN0, safeS0) = safeAccount.CreateWithdrawalSecrets(label, BigInteger.Zero);
+            var migratedCommitment = PrivacyPoolCommitment.Create(depositValue, label, safeN0, safeS0);
+
+            var postMigrationValue = depositValue / 2;
+            var (safeN1, safeS1) = safeAccount.CreateWithdrawalSecrets(label, BigInteger.One);
+            var postMigrationCommitment = PrivacyPoolCommitment.Create(
+                postMigrationValue, label, safeN1, safeS1);
+
+            var recovered = pp.RecoverAccounts(
+                new List<PoolDepositEventData>
+                {
+                    new PoolDepositEventData
+                    {
+                        Commitment = legacyCommitment.CommitmentHash,
+                        Label = label,
+                        Value = depositValue,
+                        PrecommitmentHash = legacyPrecommitment,
+                        BlockNumber = 100,
+                        TransactionHash = "0xabc"
+                    }
+                },
+                new List<PoolWithdrawalEventData>
+                {
+                    new PoolWithdrawalEventData
+                    {
+                        SpentNullifier = legacyCommitment.NullifierHash,
+                        NewCommitment = migratedCommitment.CommitmentHash,
+                        Value = 0,
+                        BlockNumber = 200,
+                        TransactionHash = "0xdef"
+                    },
+                    new PoolWithdrawalEventData
+                    {
+                        SpentNullifier = migratedCommitment.NullifierHash,
+                        NewCommitment = postMigrationCommitment.CommitmentHash,
+                        Value = depositValue - postMigrationValue,
+                        BlockNumber = 300,
+                        TransactionHash = "0xghi"
+                    }
+                },
+                new List<PoolRagequitEventData>(),
+                new List<PoolLeafEventData>
+                {
+                    new PoolLeafEventData { Leaf = legacyCommitment.CommitmentHash, Index = 0 },
+                    new PoolLeafEventData { Leaf = migratedCommitment.CommitmentHash, Index = 1 },
+                    new PoolLeafEventData { Leaf = postMigrationCommitment.CommitmentHash, Index = 2 }
+                });
+
+            Assert.Equal(2, recovered.Count);
+
+            var legacyRecovered = recovered.Find(a =>
+                a.Deposit.Commitment.CommitmentHash == legacyCommitment.CommitmentHash);
+            Assert.NotNull(legacyRecovered);
+            Assert.True(legacyRecovered.IsMigrated);
+            Assert.False(legacyRecovered.IsSpendable);
+
+            var migratedRecovered = recovered.Find(a =>
+                a.Deposit.Commitment.CommitmentHash == migratedCommitment.CommitmentHash);
+            Assert.NotNull(migratedRecovered);
+            Assert.Equal(postMigrationCommitment.CommitmentHash,
+                migratedRecovered.LatestCommitment.Commitment.CommitmentHash);
+            Assert.Equal(postMigrationValue, migratedRecovered.SpendableValue);
+            Assert.True(migratedRecovered.IsSpendable);
+            Assert.NotNull(pp.LegacyAccount);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void RecoverAccounts_MarksLegacyMigrationAsUnspendable()
+        {
+            BigInteger scope = 99;
+            var legacyAccount = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
+            var safeAccount = new PrivacyPoolAccount(TEST_MNEMONIC);
+
+            BigInteger depositIndex = 0;
+            BigInteger depositValue = 1000;
+            var (legN, legS) = legacyAccount.CreateDepositSecrets(scope, depositIndex);
+            var legacyPrecommitment = legacyAccount.ComputePrecommitment(legN, legS);
+            BigInteger label = 42;
+            var legacyCommitment = PrivacyPoolCommitment.Create(depositValue, label, legN, legS);
+
+            var (safeN, safeS) = safeAccount.CreateWithdrawalSecrets(label, BigInteger.Zero);
+            var migratedCommitment = PrivacyPoolCommitment.Create(depositValue, label, safeN, safeS);
+
+            var recovered = PrivacyPoolAccountRecovery.RecoverAccounts(
+                legacyAccount,
+                scope,
+                new List<PoolDepositEventData>
+                {
+                    new PoolDepositEventData
+                    {
+                        Commitment = legacyCommitment.CommitmentHash,
+                        Label = label,
+                        Value = depositValue,
+                        PrecommitmentHash = legacyPrecommitment,
+                        BlockNumber = 100,
+                        TransactionHash = "0xabc"
+                    }
+                },
+                new List<PoolWithdrawalEventData>
+                {
+                    new PoolWithdrawalEventData
+                    {
+                        SpentNullifier = legacyCommitment.NullifierHash,
+                        NewCommitment = migratedCommitment.CommitmentHash,
+                        Value = 0,
+                        BlockNumber = 200,
+                        TransactionHash = "0xdef"
+                    }
+                },
+                new List<PoolRagequitEventData>(),
+                new List<PoolLeafEventData>
+                {
+                    new PoolLeafEventData { Leaf = legacyCommitment.CommitmentHash, Index = 0 },
+                    new PoolLeafEventData { Leaf = migratedCommitment.CommitmentHash, Index = 1 }
+                });
+
+            Assert.Single(recovered);
+            Assert.True(recovered[0].IsMigrated);
+            Assert.False(recovered[0].IsSpendable);
+            Assert.Single(recovered[0].Withdrawals);
+            Assert.True(recovered[0].Withdrawals[0].IsMigration);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void DiscoverMigratedCommitments_RecoversSafeChainAfterMigration()
+        {
+            BigInteger scope = 99;
+            var legacyAccount = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
+            var safeAccount = new PrivacyPoolAccount(TEST_MNEMONIC);
+
+            BigInteger depositIndex = 0;
+            BigInteger depositValue = 1000;
+            var (legN, legS) = legacyAccount.CreateDepositSecrets(scope, depositIndex);
+            var legacyPrecommitment = legacyAccount.ComputePrecommitment(legN, legS);
+            BigInteger label = 42;
+            var legacyCommitment = PrivacyPoolCommitment.Create(depositValue, label, legN, legS);
+
+            var (safeN0, safeS0) = safeAccount.CreateWithdrawalSecrets(label, BigInteger.Zero);
+            var migratedCommitment = PrivacyPoolCommitment.Create(depositValue, label, safeN0, safeS0);
+
+            var postMigrationValue = depositValue / 2;
+            var (safeN1, safeS1) = safeAccount.CreateWithdrawalSecrets(label, BigInteger.One);
+            var postMigrationCommitment = PrivacyPoolCommitment.Create(
+                postMigrationValue, label, safeN1, safeS1);
+
+            var withdrawals = new List<PoolWithdrawalEventData>
+            {
+                new PoolWithdrawalEventData
+                {
+                    SpentNullifier = legacyCommitment.NullifierHash,
+                    NewCommitment = migratedCommitment.CommitmentHash,
+                    Value = 0,
+                    BlockNumber = 200,
+                    TransactionHash = "0xdef"
+                },
+                new PoolWithdrawalEventData
+                {
+                    SpentNullifier = migratedCommitment.NullifierHash,
+                    NewCommitment = postMigrationCommitment.CommitmentHash,
+                    Value = depositValue - postMigrationValue,
+                    BlockNumber = 300,
+                    TransactionHash = "0xghi"
+                }
+            };
+
+            var leafInserts = new List<PoolLeafEventData>
+            {
+                new PoolLeafEventData { Leaf = legacyCommitment.CommitmentHash, Index = 0 },
+                new PoolLeafEventData { Leaf = migratedCommitment.CommitmentHash, Index = 1 },
+                new PoolLeafEventData { Leaf = postMigrationCommitment.CommitmentHash, Index = 2 }
+            };
+
+            var legacyRecovered = PrivacyPoolAccountRecovery.RecoverAccounts(
+                legacyAccount,
+                scope,
+                new List<PoolDepositEventData>
+                {
+                    new PoolDepositEventData
+                    {
+                        Commitment = legacyCommitment.CommitmentHash,
+                        Label = label,
+                        Value = depositValue,
+                        PrecommitmentHash = legacyPrecommitment,
+                        BlockNumber = 100,
+                        TransactionHash = "0xabc"
+                    }
+                },
+                withdrawals,
+                new List<PoolRagequitEventData>(),
+                leafInserts);
+
+            var result = PrivacyPoolAccountRecovery.DiscoverMigratedCommitments(
+                safeAccount,
+                scope,
+                legacyRecovered,
+                withdrawals,
+                leafInserts,
+                new List<PoolRagequitEventData>());
+
+            Assert.Single(result);
+            Assert.Equal(migratedCommitment.CommitmentHash, result[0].Deposit.Commitment.CommitmentHash);
+            Assert.Equal(1, result[0].Deposit.LeafIndex);
+            Assert.Equal(2, result[0].Withdrawals.Count);
+            Assert.Equal(migratedCommitment.CommitmentHash, result[0].Withdrawals[0].Commitment.CommitmentHash);
+            Assert.Equal(postMigrationCommitment.CommitmentHash, result[0].LatestCommitment.Commitment.CommitmentHash);
+            Assert.Equal(postMigrationValue, result[0].SpendableValue);
+            Assert.True(result[0].IsSpendable);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void DiscoverMigratedCommitments_SkipsNonMigratedAccounts()
+        {
+            BigInteger scope = 99;
+            var legacyAccount = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
+            var safeAccount = new PrivacyPoolAccount(TEST_MNEMONIC);
+
+            var (legN, legS) = legacyAccount.CreateDepositSecrets(scope, 0);
+            BigInteger label = 42;
+            var legacyCommitment = PrivacyPoolCommitment.Create(1000, label, legN, legS);
+
+            var legacyPoolAccount = new PoolAccount
+            {
+                Scope = scope,
+                Deposit = AccountCommitment.FromCommitment(legacyCommitment, 0, 100, "0xabc")
+            };
+
+            var result = PrivacyPoolAccountRecovery.DiscoverMigratedCommitments(
+                safeAccount,
+                scope,
+                new List<PoolAccount> { legacyPoolAccount },
+                new List<PoolWithdrawalEventData>(),
+                new List<PoolLeafEventData>(),
+                new List<PoolRagequitEventData>());
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void RecoverAccounts_RagequitMatchesByLabelAfterWithdrawal()
+        {
+            BigInteger scope = 99;
+            BigInteger depositValue = 1000;
+            BigInteger label = 42;
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+
+            var (depositNullifier, depositSecret) = account.CreateDepositSecrets(scope, 0);
+            var depositPrecommitment = account.ComputePrecommitment(depositNullifier, depositSecret);
+            var depositCommitment = PrivacyPoolCommitment.Create(
+                depositValue, label, depositNullifier, depositSecret);
+
+            var remainingValue = depositValue / 2;
+            var (withdrawNullifier, withdrawSecret) = account.CreateWithdrawalSecrets(label, BigInteger.Zero);
+            var withdrawalCommitment = PrivacyPoolCommitment.Create(
+                remainingValue, label, withdrawNullifier, withdrawSecret);
+
+            var recovered = PrivacyPoolAccountRecovery.RecoverAccounts(
+                account,
+                scope,
+                new List<PoolDepositEventData>
+                {
+                    new PoolDepositEventData
+                    {
+                        Commitment = depositCommitment.CommitmentHash,
+                        Label = label,
+                        Value = depositValue,
+                        PrecommitmentHash = depositPrecommitment,
+                        BlockNumber = 100,
+                        TransactionHash = "0xabc"
+                    }
+                },
+                new List<PoolWithdrawalEventData>
+                {
+                    new PoolWithdrawalEventData
+                    {
+                        SpentNullifier = depositCommitment.NullifierHash,
+                        NewCommitment = withdrawalCommitment.CommitmentHash,
+                        Value = depositValue - remainingValue,
+                        BlockNumber = 200,
+                        TransactionHash = "0xdef"
+                    }
+                },
+                new List<PoolRagequitEventData>
+                {
+                    new PoolRagequitEventData
+                    {
+                        Commitment = withdrawalCommitment.CommitmentHash,
+                        Label = label,
+                        Value = remainingValue,
+                        BlockNumber = 300,
+                        TransactionHash = "0xghi"
+                    }
+                },
+                new List<PoolLeafEventData>
+                {
+                    new PoolLeafEventData { Leaf = depositCommitment.CommitmentHash, Index = 0 },
+                    new PoolLeafEventData { Leaf = withdrawalCommitment.CommitmentHash, Index = 1 }
+                });
+
+            Assert.Single(recovered);
+            Assert.True(recovered[0].IsRagequitted);
+            Assert.False(recovered[0].IsSpendable);
+            Assert.Equal(300, recovered[0].RagequitBlockNumber);
+        }
+
+        // ───────────────────────────────────────────────────────────
+        //  BytesToBigInt entropy preservation test
+        // ───────────────────────────────────────────────────────────
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-Account")]
+        public void BytesToBigInt_PreservesFullEntropy()
+        {
+            var bytes = new byte[32];
+            bytes[0] = 0xFF;
+            bytes[31] = 0x01;
+            var result = PrivacyPoolAccount.BytesToBigInt(bytes);
+            // Should be much larger than 2^53 (the lossy double limit)
+            Assert.True(result > BigInteger.Pow(2, 53));
+            // Roundtrip: converting back should give same bytes
+            var roundtrip = result.ToByteArray(isUnsigned: true, isBigEndian: true);
+            Assert.Equal(bytes, roundtrip);
         }
     }
 }

--- a/tests/Nethereum.PrivacyPools.Tests/ArtifactVerificationTests.cs
+++ b/tests/Nethereum.PrivacyPools.Tests/ArtifactVerificationTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Nethereum.PrivacyPools.Circuits;
+using Xunit;
+
+namespace Nethereum.PrivacyPools.Tests
+{
+    public class ArtifactVerificationTests : IDisposable
+    {
+        private readonly string _cacheDir;
+
+        public ArtifactVerificationTests()
+        {
+            _cacheDir = Path.Combine(Path.GetTempPath(), $"artifact-test-{Guid.NewGuid()}");
+            Directory.CreateDirectory(_cacheDir);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_cacheDir))
+                Directory.Delete(_cacheDir, recursive: true);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-ArtifactVerification")]
+        public async Task CorrectHash_LoadsSuccessfully()
+        {
+            var testBytes = new byte[] { 1, 2, 3, 4, 5 };
+            File.WriteAllBytes(Path.Combine(_cacheDir, "test.wasm"), testBytes);
+
+            using var sha = SHA256.Create();
+            var hash = BitConverter.ToString(sha.ComputeHash(testBytes))
+                .Replace("-", "").ToLowerInvariant();
+
+            var hashes = new Dictionary<string, string> { ["test.wasm"] = hash };
+            var source = new UrlCircuitArtifactSource("http://unused",
+                cacheDir: _cacheDir, expectedHashes: hashes);
+
+            var result = await source.GetWasmAsync("test");
+
+            Assert.Equal(testBytes, result);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-ArtifactVerification")]
+        public async Task WrongHash_ThrowsInvalidOperationException()
+        {
+            var testBytes = new byte[] { 1, 2, 3, 4, 5 };
+            File.WriteAllBytes(Path.Combine(_cacheDir, "test.wasm"), testBytes);
+
+            var hashes = new Dictionary<string, string>
+            {
+                ["test.wasm"] = "0000000000000000000000000000000000000000000000000000000000000000"
+            };
+            var source = new UrlCircuitArtifactSource("http://unused",
+                cacheDir: _cacheDir, expectedHashes: hashes);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => source.GetWasmAsync("test"));
+
+            Assert.Contains("Integrity check failed", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-ArtifactVerification")]
+        public async Task BuiltInHashes_LoadCanonicalArtifactNames()
+        {
+            var embedded = new PrivacyPoolCircuitSource();
+
+            File.WriteAllBytes(Path.Combine(_cacheDir, "commitment.wasm"),
+                await embedded.GetWasmAsync("commitment"));
+            File.WriteAllBytes(Path.Combine(_cacheDir, "commitment.zkey"),
+                await embedded.GetZkeyAsync("commitment"));
+            File.WriteAllText(Path.Combine(_cacheDir, "commitment.vkey"),
+                NormalizeToLf(embedded.GetVerificationKeyJson("commitment")),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            File.WriteAllBytes(Path.Combine(_cacheDir, "withdraw.wasm"),
+                await embedded.GetWasmAsync("withdrawal"));
+            File.WriteAllBytes(Path.Combine(_cacheDir, "withdraw.zkey"),
+                await embedded.GetZkeyAsync("withdrawal"));
+            File.WriteAllText(Path.Combine(_cacheDir, "withdraw.vkey"),
+                NormalizeToLf(embedded.GetVerificationKeyJson("withdrawal")),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            var source = new UrlCircuitArtifactSource("http://unused", cacheDir: _cacheDir);
+
+            var commitmentWasm = await source.GetWasmAsync("commitment");
+            var withdrawalZkey = await source.GetZkeyAsync("withdrawal");
+            var commitmentVkey = source.GetVerificationKeyJson("commitment");
+            var withdrawalVkey = source.GetVerificationKeyJson("withdrawal");
+
+            Assert.NotEmpty(commitmentWasm);
+            Assert.NotEmpty(withdrawalZkey);
+            Assert.Contains("\"protocol\": \"groth16\"", commitmentVkey);
+            Assert.Contains("\"protocol\": \"groth16\"", withdrawalVkey);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-ArtifactVerification")]
+        public async Task MissingHash_ThrowsInvalidOperationException()
+        {
+            var testBytes = new byte[] { 10, 20, 30 };
+            File.WriteAllBytes(Path.Combine(_cacheDir, "test.wasm"), testBytes);
+
+            var source = new UrlCircuitArtifactSource("http://unused",
+                cacheDir: _cacheDir,
+                expectedHashes: new Dictionary<string, string>());
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => source.GetWasmAsync("test"));
+
+            Assert.Contains("Refusing to load unverified artifact", ex.Message);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-ArtifactVerification")]
+        public void CircuitArtifactHashes_ContainsAllExpectedEntries()
+        {
+            var hashes = CircuitArtifactHashes.Default;
+
+            Assert.Equal(10, hashes.Count);
+            Assert.True(hashes.ContainsKey("commitment.wasm"));
+            Assert.True(hashes.ContainsKey("commitment.zkey"));
+            Assert.True(hashes.ContainsKey("commitment.vkey"));
+            Assert.True(hashes.ContainsKey("commitment_vk.json"));
+            Assert.True(hashes.ContainsKey("withdraw.wasm"));
+            Assert.True(hashes.ContainsKey("withdraw.zkey"));
+            Assert.True(hashes.ContainsKey("withdraw.vkey"));
+            Assert.True(hashes.ContainsKey("withdrawal.wasm"));
+            Assert.True(hashes.ContainsKey("withdrawal.zkey"));
+            Assert.True(hashes.ContainsKey("withdrawal_vk.json"));
+        }
+
+        private static string NormalizeToLf(string text)
+        {
+            return text.Replace("\r\n", "\n");
+        }
+    }
+}

--- a/tests/Nethereum.PrivacyPools.Tests/CrossCompatibilityTests.cs
+++ b/tests/Nethereum.PrivacyPools.Tests/CrossCompatibilityTests.cs
@@ -45,10 +45,9 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-CrossCompat")]
-        [NethereumDocExample(DocSection.Protocols, "cross-compatibility", "Master keys match 0xbow TypeScript SDK")]
-        public void MasterKeys_MatchJavaScript()
+        public void Legacy_MasterKeys_MatchJavaScript()
         {
-            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
 
             Assert.Equal(
                 BigInteger.Parse("16629217087516280053769625512741000936965671973118241282486996830438009025879"),
@@ -61,9 +60,25 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-CrossCompat")]
-        public void DepositSecrets_Scope12345_Index0_MatchJavaScript()
+        [NethereumDocExample(DocSection.Protocols, "cross-compatibility", "Master keys match 0xbow TypeScript SDK")]
+        public void Safe_MasterKeys_MatchJavaScript()
         {
             var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+
+            Assert.Equal(
+                BigInteger.Parse("20068762160393292801596226195912281868434195939362930533775271887246872084568"),
+                account.MasterNullifier);
+
+            Assert.Equal(
+                BigInteger.Parse("4263194520628581151689140073493505946870598678660509318310629023735624352890"),
+                account.MasterSecret);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-CrossCompat")]
+        public void Legacy_DepositSecrets_Scope12345_Index0_MatchJavaScript()
+        {
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             var (nullifier, secret) = account.CreateDepositSecrets(scope: 12345, depositIndex: 0);
 
             Assert.Equal(
@@ -77,9 +92,25 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-CrossCompat")]
-        public void DepositSecrets_Scope12345_Index1_MatchJavaScript()
+        public void Safe_DepositSecrets_Scope12345_Index0_MatchJavaScript()
         {
             var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var (nullifier, secret) = account.CreateDepositSecrets(scope: 12345, depositIndex: 0);
+
+            Assert.Equal(
+                BigInteger.Parse("18799083407603226543886233241239845601765199220468928197737203484264534974328"),
+                nullifier);
+
+            Assert.Equal(
+                BigInteger.Parse("15330187620018206781186163615746153118874798050558698314725491067582470174001"),
+                secret);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-CrossCompat")]
+        public void Legacy_DepositSecrets_Scope12345_Index1_MatchJavaScript()
+        {
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             var (nullifier, secret) = account.CreateDepositSecrets(scope: 12345, depositIndex: 1);
 
             Assert.Equal(
@@ -93,9 +124,25 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-CrossCompat")]
-        public void Precommitment_MatchesJavaScript()
+        public void Safe_DepositSecrets_Scope12345_Index1_MatchJavaScript()
         {
             var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var (nullifier, secret) = account.CreateDepositSecrets(scope: 12345, depositIndex: 1);
+
+            Assert.Equal(
+                BigInteger.Parse("19680772378616183859773159152052009318547743051040396428045076615829991543806"),
+                nullifier);
+
+            Assert.Equal(
+                BigInteger.Parse("6904700659503672703719873229706944332624720037700303163123064806497600512042"),
+                secret);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-CrossCompat")]
+        public void Legacy_Precommitment_MatchesJavaScript()
+        {
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             var (nullifier, secret) = account.CreateDepositSecrets(scope: 12345, depositIndex: 0);
             var precommitment = account.ComputePrecommitment(nullifier, secret);
 
@@ -106,10 +153,22 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-CrossCompat")]
-        [NethereumDocExample(DocSection.Protocols, "cross-compatibility", "Commitment hash matches 0xbow SDK", Order = 2)]
-        public void CommitmentHash_MatchesJavaScript()
+        public void Safe_Precommitment_MatchesJavaScript()
         {
             var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var (nullifier, secret) = account.CreateDepositSecrets(scope: 12345, depositIndex: 0);
+            var precommitment = account.ComputePrecommitment(nullifier, secret);
+
+            Assert.Equal(
+                BigInteger.Parse("20989285794294416915427341900376611790943415285600831049009268118579350954735"),
+                precommitment);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-CrossCompat")]
+        public void Legacy_CommitmentHash_MatchesJavaScript()
+        {
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             var (nullifier, secret) = account.CreateDepositSecrets(scope: 12345, depositIndex: 0);
 
             var value = BigInteger.Parse("1000000000000000000");
@@ -123,9 +182,26 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-CrossCompat")]
-        public void NullifierHash_IsPoseidonOfNullifierOnly()
+        [NethereumDocExample(DocSection.Protocols, "cross-compatibility", "Commitment hash matches 0xbow SDK", Order = 2)]
+        public void Safe_CommitmentHash_MatchesJavaScript()
         {
             var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var (nullifier, secret) = account.CreateDepositSecrets(scope: 12345, depositIndex: 0);
+
+            var value = BigInteger.Parse("1000000000000000000");
+            var label = new BigInteger(42);
+            var commitment = PrivacyPoolCommitment.Create(value, label, nullifier, secret);
+
+            Assert.Equal(
+                BigInteger.Parse("2437259894778772672765342353008225556665669965602864891664011882809548214291"),
+                commitment.CommitmentHash);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-CrossCompat")]
+        public void Legacy_NullifierHash_IsPoseidonOfNullifierOnly()
+        {
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             var (nullifier, secret) = account.CreateDepositSecrets(scope: 12345, depositIndex: 0);
 
             var commitment = PrivacyPoolCommitment.Create(
@@ -142,9 +218,28 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-CrossCompat")]
-        public void WithdrawalSecrets_Label42_Index0_MatchJavaScript()
+        public void Safe_NullifierHash_IsPoseidonOfNullifierOnly()
         {
             var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var (nullifier, secret) = account.CreateDepositSecrets(scope: 12345, depositIndex: 0);
+
+            var commitment = PrivacyPoolCommitment.Create(
+                BigInteger.Parse("1000000000000000000"), new BigInteger(42), nullifier, secret);
+
+            var hasherT1 = new PoseidonHasher(PoseidonParameterPreset.CircomT1);
+            var expectedNullifierHash = hasherT1.Hash(nullifier);
+            Assert.Equal(expectedNullifierHash, commitment.NullifierHash);
+
+            Assert.Equal(
+                BigInteger.Parse("20989285794294416915427341900376611790943415285600831049009268118579350954735"),
+                commitment.Precommitment);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-CrossCompat")]
+        public void Legacy_WithdrawalSecrets_Label42_Index0_MatchJavaScript()
+        {
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
             var (nullifier, secret) = account.CreateWithdrawalSecrets(label: 42, childIndex: 0);
 
             Assert.Equal(
@@ -153,6 +248,22 @@ namespace Nethereum.PrivacyPools.Tests
 
             Assert.Equal(
                 BigInteger.Parse("10792736894102772735736614277228776044074280264945699122691537450345638664651"),
+                secret);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-CrossCompat")]
+        public void Safe_WithdrawalSecrets_Label42_Index0_MatchJavaScript()
+        {
+            var account = new PrivacyPoolAccount(TEST_MNEMONIC);
+            var (nullifier, secret) = account.CreateWithdrawalSecrets(label: 42, childIndex: 0);
+
+            Assert.Equal(
+                BigInteger.Parse("1980872316991559359161330914646252222519000137922535899794170500197294191442"),
+                nullifier);
+
+            Assert.Equal(
+                BigInteger.Parse("21563020234007267038495623498396204986995053023966409630658634968140121948420"),
                 secret);
         }
 
@@ -177,7 +288,40 @@ namespace Nethereum.PrivacyPools.Tests
 
         [Fact]
         [Trait("Category", "PrivacyPools-CrossCompat")]
-        public void FullRecoveryFlow_CrossCompatible()
+        public void Legacy_FullRecoveryFlow_CrossCompatible()
+        {
+            var account = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
+            BigInteger scope = 12345;
+            BigInteger value = BigInteger.Parse("1000000000000000000");
+            BigInteger label = 42;
+
+            var (n, s) = account.CreateDepositSecrets(scope, 0);
+            var commitment = PrivacyPoolCommitment.Create(value, label, n, s);
+
+            Assert.Equal(
+                BigInteger.Parse("6581052328044309944572509229741643068124058879852680304301405212883947166909"),
+                commitment.CommitmentHash);
+
+            var (wn, ws) = account.CreateWithdrawalSecrets(label, 0);
+            var halfValue = value / 2;
+            var newCommitment = PrivacyPoolCommitment.Create(halfValue, label, wn, ws);
+
+            Assert.NotEqual(commitment.CommitmentHash, newCommitment.CommitmentHash);
+            Assert.Equal(halfValue, newCommitment.Value);
+
+            var account2 = PrivacyPoolAccount.CreateLegacy(TEST_MNEMONIC);
+            var (n2, s2) = account2.CreateDepositSecrets(scope, 0);
+            Assert.Equal(n, n2);
+            Assert.Equal(s, s2);
+
+            var (wn2, ws2) = account2.CreateWithdrawalSecrets(label, 0);
+            Assert.Equal(wn, wn2);
+            Assert.Equal(ws, ws2);
+        }
+
+        [Fact]
+        [Trait("Category", "PrivacyPools-CrossCompat")]
+        public void Safe_FullRecoveryFlow_CrossCompatible()
         {
             var account = new PrivacyPoolAccount(TEST_MNEMONIC);
             BigInteger scope = 12345;
@@ -188,7 +332,7 @@ namespace Nethereum.PrivacyPools.Tests
             var commitment = PrivacyPoolCommitment.Create(value, label, n, s);
 
             Assert.Equal(
-                BigInteger.Parse("6581052328044309944572509229741643068124058879852680304301405212883947166909"),
+                BigInteger.Parse("2437259894778772672765342353008225556665669965602864891664011882809548214291"),
                 commitment.CommitmentHash);
 
             var (wn, ws) = account.CreateWithdrawalSecrets(label, 0);

--- a/tests/Nethereum.PrivacyPools.Tests/Nethereum.PrivacyPools.Tests.csproj
+++ b/tests/Nethereum.PrivacyPools.Tests/Nethereum.PrivacyPools.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Nethereum.PrivacyPools.Circuits\Nethereum.PrivacyPools.Circuits.csproj" />
     <ProjectReference Include="..\..\src\Nethereum.PrivacyPools\Nethereum.PrivacyPools.csproj" />
     <ProjectReference Include="..\..\src\Nethereum.Documentation\Nethereum.Documentation.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Why

The [0xbow Privacy Pools SDK v1.2.0](https://www.npmjs.com/package/@0xbow/privacy-pools-core-sdk) changed how master keys are derived from a mnemonic. It switched from `bytesToNumber` (JavaScript `Number`, truncated to ~53 bits) to `bytesToBigInt` (full 256-bit entropy). The old path silently discarded ~203 bits of key material.

This PR updates `Nethereum.PrivacyPools` to match, while preserving backward compatibility with deposits made before the change.

---

## What changed

### 1. Key derivation (`PrivacyPoolAccount.cs`)

- **Default constructor** now uses `BytesToBigInt` (full 256-bit big-endian), matching `viem.bytesToBigInt`
- **`CreateLegacy()`** factory preserves the lossy `bytesToNumber` path for recovering pre-v1.2.0 deposits
- Both paths derive from the same HD paths: `m/44'/60'/0'/0/0` and `m/44'/60'/1'/0/0`

### 2. Migration-aware recovery (`PrivacyPoolAccountRecovery.cs`, `PrivacyPool.cs`)

`RecoverAccounts` now follows the SDK v1.2.0 three-phase pipeline:

1. **Legacy recovery**: scan for deposits made with truncated keys
2. **Migration discovery**: detect legacy deposits that were migrated to safe keys via a key-rotation withdrawal (label match, withdrawal index 0, `newCommitment` hash verification)
3. **Safe recovery**: scan for deposits made with full-entropy keys, starting after migrated accounts

Supporting changes:
- `EventLookups` internal class shares pre-built dictionaries to avoid redundant iteration
- Ragequit matching uses **label** (not commitment hash) per SDK v1.2.0
- `IsMigrated` / `IsMigration` flags track migration state; migrated legacy accounts are excluded from `IsSpendable`
- `RecoverSafeAccounts` / `SyncSafeFromChainAsync` for callers that only need safe-key deposits
- `LeafIndex < 0` guard in `WithdrawDirectAsync` prevents invalid Merkle proofs

### 3. Artifact integrity (`CircuitArtifactHashes.cs`, `UrlCircuitArtifactSource.cs`)

- Every downloaded circuit artifact is verified against the SDK v1.2.0 SHA-256 hash manifest before use
- Unknown artifacts are rejected to prevent loading tampered circuits
- File name aliasing handles the `withdraw`/`withdrawal` naming discrepancy between SDK versions

### 4. Account model (`AccountCommitment.cs`)

- `IsMigration` flag on `AccountCommitment` marks the withdrawal that performed the key rotation
- `IsMigrated` flag on `PoolAccount` marks legacy accounts whose funds moved to safe keys
- `IsSpendable` updated: `!IsRagequitted && !IsMigrated && Value > 0`

---

## Files changed

| File | Lines | Description |
|------|-------|-------------|
| `PrivacyPoolAccount.cs` | +27 /−10 | `BytesToBigInt`, `CreateLegacy()`, private constructor with `useLegacyDerivation` flag |
| `PrivacyPoolAccountRecovery.cs` | +190 /−8 | `EventLookups`, `DiscoverMigratedCommitments`, ragequit-by-label, `startIndex` param |
| `PrivacyPool.cs` | +100 /−14 | Dual-account constructors, `RecoverSafeAccounts`, `SyncSafeFromChainAsync`, `LeafIndex` guard |
| `AccountCommitment.cs` | +9 /−5 | `IsMigration`, `IsMigrated`, updated `IsSpendable` |
| `CircuitArtifactHashes.cs` | +27 (new) | SHA-256 manifest for 6 circuit artifacts |
| `UrlCircuitArtifactSource.cs` | +156 /−62 | Integrity verification, file name aliasing, `using var` disposal |
| `README.md` | +26 /−5 | Updated code examples and cross-compatibility section |
| Tests (10 files) | +1,326 | See below |

---

## Test coverage

| Suite | Count | What it covers |
|-------|-------|----------------|
| Unit tests | 98 | Legacy/safe key derivation, deposit/withdrawal secrets, precommitment matching, migration discovery, ragequit-by-label, spendable value tracking, entropy preservation |
| Circuit E2E | 15 | Full deposit → withdrawal → ragequit cycles with Groth16 proofs on Geth devchain |
| Cross-SDK | 9 | Bidirectional interop with TS SDK v1.2.0 (TS deposit → C# withdrawal and vice versa, ETH + ERC20) |
| Artifact verification | 5 | Correct hash, wrong hash, missing hash, default manifest, LF-normalized vkey |
| Cross-compatibility | 20 | Hardcoded expected values from `@0xbow/privacy-pools-core-sdk@1.2.0` |

All 113 runnable tests pass (unit + circuit E2E). Cross-SDK tests require a running TS companion.