### PR TITLE
docs: replace dead facilitator.x402.org with live x402.org/facilitator

### DIFF
--- a/plugins/nethereum-skills/skills/x402-payments/SKILL.md
+++ b/plugins/nethereum-skills/skills/x402-payments/SKILL.md
@@ -75,7 +75,7 @@ using Nethereum.X402.AspNetCore;
 using Nethereum.X402.Server;
 using Nethereum.X402.Models;
 
-builder.Services.AddX402Services("https://facilitator.x402.org");
+builder.Services.AddX402Services("https://x402.org/facilitator");
 
 app.UseX402(options =>
 {

--- a/src/Nethereum.X402/AspNetCore/X402Options.cs
+++ b/src/Nethereum.X402/AspNetCore/X402Options.cs
@@ -15,7 +15,7 @@ public class X402Options
 
     /// <summary>
     /// Base URL for the facilitator service.
-    /// Example: "https://facilitator.x402.org"
+    /// Example: "https://x402.org/facilitator"
     /// </summary>
     public string? FacilitatorUrl { get; set; }
 

--- a/src/Nethereum.X402/README.md
+++ b/src/Nethereum.X402/README.md
@@ -108,7 +108,7 @@ using Nethereum.X402.Models;
 var builder = WebApplication.CreateBuilder(args);
 
 // Register x402 services with a facilitator
-builder.Services.AddX402Services("https://facilitator.x402.org");
+builder.Services.AddX402Services("https://x402.org/facilitator");
 
 var app = builder.Build();
 
@@ -340,7 +340,7 @@ A facilitator is a service that verifies and settles payments on behalf of API s
 ```csharp
 using Nethereum.X402.Facilitator;
 
-var facilitatorClient = new HttpFacilitatorClient(httpClient, "https://facilitator.x402.org");
+var facilitatorClient = new HttpFacilitatorClient(httpClient, "https://x402.org/facilitator");
 
 var verification = await facilitatorClient.VerifyAsync(paymentPayload, requirements);
 var settlement = await facilitatorClient.SettleAsync(paymentPayload, requirements);


### PR DESCRIPTION
`https://facilitator.x402.org` has no DNS record (NXDOMAIN), but it appears as the facilitator example in `X402Options.cs` doc-comments, the Nethereum.X402 README, and the x402-payments skill — so configs copied from these examples fail at their first request. The x402 project's live endpoint is `https://x402.org/facilitator` (verified serving `GET /supported`; the upstream x402 repo fixed the same dead host in x402-foundation/x402#2787).

4 occurrences replaced across 3 files. Docs/comments only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018p8jtKC5g7uUMrjGCWksqu